### PR TITLE
Support for ton:// in Desktop Wallet

### DIFF
--- a/apps/desktop/src/electron/protocol.ts
+++ b/apps/desktop/src/electron/protocol.ts
@@ -5,6 +5,7 @@ import { MainWindow } from './mainWindow';
 
 export const setDefaultProtocolClient = () => {
     if (!app.isDefaultProtocolClient('tc')) {
+        app.setAsDefaultProtocolClient('ton');
         app.setAsDefaultProtocolClient('tc');
         app.setAsDefaultProtocolClient('tonkeeper');
         app.setAsDefaultProtocolClient('tonkeeper-tc');

--- a/apps/desktop/src/electron/protocol.ts
+++ b/apps/desktop/src/electron/protocol.ts
@@ -4,7 +4,7 @@ import log from 'electron-log/main';
 import { MainWindow } from './mainWindow';
 
 export const setDefaultProtocolClient = () => {
-    if (!app.isDefaultProtocolClient('tc')) {
+    if (!app.isDefaultProtocolClient('tc') || !app.isDefaultProtocolClient('tonkeeper-tc')) {
         app.setAsDefaultProtocolClient('ton');
         app.setAsDefaultProtocolClient('tc');
         app.setAsDefaultProtocolClient('tonkeeper');


### PR DESCRIPTION
Most websites and apps use `ton://` to register with the desktop app for convenience.

Additionally, consider adding further checks for `tonkeeper-tc://`, as it has been observed that TON Connect sometimes fails to register. This issue is relevant to the latest v2.0.3 `@tonconnect/ui` calls with tonkeeper-web wallet.

Update: Added `if` check for `tonkeeper-tc` registration.

Thank you! Keep up the good work!