### PR TITLE
Validate the ton:// protocol registration

### DIFF
--- a/apps/desktop/src/electron/protocol.ts
+++ b/apps/desktop/src/electron/protocol.ts
@@ -4,11 +4,10 @@ import log from 'electron-log/main';
 import { MainWindow } from './mainWindow';
 
 export const setDefaultProtocolClient = () => {
-    if (!app.isDefaultProtocolClient('tc') || !app.isDefaultProtocolClient('tonkeeper-tc')) {
-        app.setAsDefaultProtocolClient('ton');
-        app.setAsDefaultProtocolClient('tc');
-        app.setAsDefaultProtocolClient('tonkeeper');
-        app.setAsDefaultProtocolClient('tonkeeper-tc');
+    const protocols = ['ton', 'tc', 'tonkeeper', 'tonkeeper-tc'];
+    const isDefaultProtocolClient = protocols.every(protocol => app.isDefaultProtocolClient(protocol));
+    if (!isDefaultProtocolClient) {
+        protocols.forEach(protocol => app.setAsDefaultProtocolClient(protocol));
     }
 };
 


### PR DESCRIPTION
Simplified the function of `setDefaultProtocolClient` and ensured the registration of `ton://` and `tonkeeper://` handles.

This is an addition to the previous pull request to ensure the handles are properly registered, even if other TON wallets are installed on the system.

Reference: [https://github.com/tonkeeper/tonkeeper-web/pull/96](https://github.com/tonkeeper/tonkeeper-web/pull/96)