### PR TITLE
Formatting small numbers like 0.0{4}123

### DIFF
--- a/packages/core/src/utils/AmountFormatter.ts
+++ b/packages/core/src/utils/AmountFormatter.ts
@@ -93,6 +93,16 @@ export class AmountFormatter {
             suffix
         };
 
+        // Custom formatting for numbers with more than 3 decimal zeros
+        if (bn.isGreaterThan(0) && bn.isLessThan('0.001')) {
+            const decimalStr = bn.toFixed(20).split('.')[1];
+            const leadingZeros = decimalStr.match(/^0+/)![0]!.length;
+            if (leadingZeros > 3) {
+                const significantDigits = decimalStr.slice(leadingZeros, leadingZeros + decimals);
+                return `${prefix}0${decimalSeparator}0{${leadingZeros}}${significantDigits}${suffix}`;
+            }
+        }
+
         // truncate decimals 1.00 -> 1
         if (!options.ignoreZeroTruncate && bn.isLessThan('0.01')) {
             bn = bn.decimalPlaces(new BigNumber(decimals).toNumber(), BigNumber.ROUND_DOWN);

--- a/packages/uikit/src/components/home/Balance.tsx
+++ b/packages/uikit/src/components/home/Balance.tsx
@@ -132,7 +132,7 @@ export const Balance: FC<{
     return (
         <Block>
             <MessageBlock error={error} isFetching={isFetching} />
-            <Amount>{formatFiatCurrency(fiat, total || 0)}</Amount>
+            <Amount>{formatFiatCurrency(fiat, total || 0, true)}</Amount>
             <Body onClick={() => sdk.copyToClipboard(address)}>
                 {toShortValue(address)}
                 <Label />

--- a/packages/uikit/src/components/home/TokenLayout.tsx
+++ b/packages/uikit/src/components/home/TokenLayout.tsx
@@ -85,26 +85,27 @@ export const TokenLayout: FC<{
     verification?: JettonVerificationType;
 }> = ({ name, symbol, balance, secondary, fiatAmount, label, rate, verification }) => {
     const { t } = useTranslation();
+    const NameWrapper = verification === 'none' ? Unverified : React.Fragment;
 
     return (
         <Description>
             <FirstLine>
                 <CoinName>
-                    {symbol ?? name}
-                    {label ? <CoinLabel>{label}</CoinLabel> : null}
+                    <NameWrapper>
+                        {symbol ?? name ?? t('approval_unverified_token')}
+                        {label ? <CoinLabel>{label}</CoinLabel> : null}
+                    </NameWrapper>
                 </CoinName>
                 <Symbol></Symbol>
                 <Label1>{balance}</Label1>
             </FirstLine>
             <SecondLine>
+                <Secondary>{secondary}</Secondary>
                 <Secondary>
-                    {verification === 'none' ? (
-                        <Unverified>{t('approval_unverified_token')}</Unverified>
-                    ) : (
-                        <>
-                            {secondary} <Delta data={rate} />
-                        </>
-                    )}
+                    <>
+                        <Delta data={rate} />
+                        <Delta data={rate} time="7d" />
+                    </>
                 </Secondary>
                 <Secondary>{fiatAmount}</Secondary>
             </SecondLine>
@@ -126,8 +127,14 @@ const DeltaColor = styled.span<{ positive: boolean }>`
             `}}
 `;
 
-const Delta: FC<{ data: TokenRate | undefined }> = ({ data }) => {
-    if (!data || !data.diff24h || data.diff24h == '0.00%') return null;
-    const positive = data.diff24h.startsWith('+');
-    return <DeltaColor positive={positive}>{data.diff24h}</DeltaColor>;
+const Delta: FC<{ data: TokenRate | undefined; time?: string }> = ({ data, time = '24h' }) => {
+    const diff = `diff${time}` as keyof TokenRate;
+    const change: string = data![diff];
+    if (!change || change === '0.00%') return null;
+    const positive = change.startsWith('+');
+    return (
+        <DeltaColor positive={positive}>
+            {change} ({time})
+        </DeltaColor>
+    );
 };

--- a/packages/uikit/src/hooks/balance.ts
+++ b/packages/uikit/src/hooks/balance.ts
@@ -41,10 +41,15 @@ export const useFormatCoinValue = () => {
     }, []);
 };
 
-export const formatFiatCurrency = (currency: FiatCurrencies, balance: BigNumber.Value) => {
+export const formatFiatCurrency = (
+    currency: FiatCurrencies,
+    balance: BigNumber.Value,
+    fixedPrecision = false
+) => {
     return formatter.format(balance.toString(), {
         currency: currency,
         ignoreZeroTruncate: false,
-        decimals: 4
+        decimals: fixedPrecision ? 2 : 4,
+        fixedPrecision
     });
 };

--- a/packages/uikit/src/state/rates.ts
+++ b/packages/uikit/src/state/rates.ts
@@ -101,7 +101,7 @@ export const useFormatFiat = (rate: TokenRate | undefined, tokenAmount: BigNumbe
         if (!rate) return [undefined, undefined] as const;
         return [
             formatFiatCurrency(fiat, rate.prices),
-            formatFiatCurrency(fiat, new BigNumber(rate.prices).multipliedBy(tokenAmount))
+            formatFiatCurrency(fiat, new BigNumber(rate.prices).multipliedBy(tokenAmount), true)
         ] as const;
     }, [rate, fiat, tokenAmount]);
     return {


### PR DESCRIPTION
Very small numbers get shown as 0.0, which does not work for a lot of coins. This change formats them like 0.0{number of zeros} plus the configured number of decimal places.