### PR TITLE
fix(PRO-405): handle tgAuthResult in web and desktop

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -21,11 +21,11 @@ jobs:
                       command: publish:arm
                     - os: windows-latest
                       command: publish:intel
-                    - os: macos-13
+                    - os: macos-15-intel
                       command: publish:intel
-                    - os: macos-13
+                    - os: macos-latest
                       command: publish:arm
-                    - os: macos-13
+                    - os: macos-latest
                       command: publish:universal
 
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,15 +26,15 @@ jobs:
                       command: make:intel
                       tag: x64
                       dist: /apps/desktop/out/make/squirrel.windows/x64/*Setup.exe
-                    - os: macos-13
+                    - os: macos-15-intel
                       command: make:intel
                       tag: x64
                       dist: /apps/desktop/out/make
-                    - os: macos-13
+                    - os: macos-latest
                       command: make:arm
                       tag: arm
                       dist: /apps/desktop/out/make
-                    - os: macos-13
+                    - os: macos-latest
                       command: make:universal
                       tag: universal
                       dist: /apps/desktop/out/make

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,162 @@
+# Contributing to Tonkeeper Web
+
+This document describes the development workflow and conventions used in this project.
+
+## Branch Naming
+
+```
+feature/<description>     — new features
+fix/<description>         — bug fixes
+hotfix/<description>      — urgent production fixes
+```
+
+**Examples:**
+- `feature/wallet-connect-v2`
+- `fix/transaction-signing`
+- `fix/PRO-123-popup-issue`
+- `hotfix/critical-security-patch`
+
+## Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>(<scope>): <description>
+```
+
+**Types:**
+- `feat` — new feature
+- `fix` — bug fix
+- `chore` — maintenance (dependencies, release, etc.)
+- `refactor` — code refactoring
+- `docs` — documentation changes
+
+**Scopes (optional):**
+`desktop`, `extension`, `web`, `core`, `uikit`, `locales`, `mobile`, `twa`
+
+**Examples:**
+```
+feat(extension): add Firefox manifest v3 support
+fix(desktop): resolve crash on large NFT collections
+fix(PRO-123): transaction signing error
+chore: update dependencies
+chore: release 4.3.4
+```
+
+## Development Workflow
+
+### 1. Create a branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feature/my-feature
+```
+
+### 2. Make changes and commit
+
+```bash
+git add .
+git commit -m "feat: add new feature"
+```
+
+### 3. Push and create a Pull Request
+
+```bash
+git push origin feature/my-feature
+gh pr create --base main
+```
+
+Or create PR via GitHub UI.
+
+### 4. CI Checks
+
+When you open a PR, the following builds run automatically:
+- Desktop (Linux, Windows, macOS)
+- Web (preview deployment)
+- Extension (Chrome, Firefox)
+- iPad
+
+### 5. Code Review and Merge
+
+After approval, the PR is merged into `main` using merge commit.
+
+## Release Process
+
+### 1. Update versions
+
+Update version in the following files:
+- `package.json` (root)
+- `apps/web/package.json`
+- `apps/desktop/package.json`
+- `apps/extension/package.json`
+
+### 2. Create release commit
+
+```bash
+git add .
+git commit -m "chore: release X.Y.Z"
+```
+
+### 3. Create and push tag
+
+```bash
+git tag vX.Y.Z
+git push origin main
+git push origin vX.Y.Z
+```
+
+### 4. Automated deployment
+
+Pushing a tag triggers the CD workflow which:
+- Builds and publishes Desktop apps to GitHub Release
+- Deploys Web app to production
+- Builds and uploads browser extensions
+- Uploads iPad build to TestFlight
+
+## Versioning
+
+We use [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`
+
+- **PATCH** — bug fixes (4.3.4 → 4.3.5)
+- **MINOR** — new features, backward compatible (4.3.4 → 4.4.0)
+- **MAJOR** — breaking changes (4.3.4 → 5.0.0)
+
+All apps (web, desktop, extension) share the same version number.
+
+## Project Structure
+
+```
+tonkeeper-web/
+├── apps/
+│   ├── desktop/      — Electron desktop app
+│   ├── extension/    — Browser extension (Chrome, Firefox)
+│   ├── web/          — Web application
+│   ├── mobile/       — Mobile/iPad app (Capacitor)
+│   ├── twa/          — Telegram Web App
+│   └── web-swap-widget/
+├── packages/
+│   ├── core/         — Core business logic
+│   ├── uikit/        — UI components
+│   └── locales/      — Translations
+└── .github/
+    └── workflows/    — CI/CD pipelines
+```
+
+## Useful Commands
+
+```bash
+# Install dependencies
+yarn install
+
+# Build all packages
+yarn build:pkg
+
+# Run web app locally
+yarn start:web
+
+# Build for production
+yarn build:web
+yarn build:desktop
+yarn build:extension
+```

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@tonkeeper/desktop",
     "license": "Apache-2.0",
-    "version": "4.3.4",
+    "version": "4.3.5",
     "description": "Your desktop wallet on The Open Network",
     "main": ".webpack/main",
     "repository": {

--- a/apps/desktop/src/react.tsx
+++ b/apps/desktop/src/react.tsx
@@ -1,6 +1,16 @@
 import { createRoot } from 'react-dom/client';
 import { App } from './app/App';
 import './app/i18n';
+import { getTgAuthResult, sendTgAuthResultToOpener } from "@tonkeeper/core/dist/service/telegramOauth";
+
+try {
+  const tgAuthResult = getTgAuthResult();
+  if (tgAuthResult) {
+    sendTgAuthResultToOpener(tgAuthResult);
+  }
+} catch (e) {
+  console.error(e);
+}
 
 const root = createRoot(document.getElementById('root'));
 root.render(<App />);

--- a/apps/desktop/src/telegram-widget.js
+++ b/apps/desktop/src/telegram-widget.js
@@ -562,7 +562,7 @@
         xhr.onerror = function() {
           callback('*', false);
         };
-/*PATCHED*/ xhr.withCredentials = false;
+/*PATCHED*/ xhr.withCredentials = false; // Electron manages cookies via onBeforeSendHeaders in mainWindow.ts
         xhr.send('bot_id=' + encodeURIComponent(options.bot_id) + (options.lang ? '&lang=' + encodeURIComponent(options.lang) : ''));
       }
     };

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tonkeeper/extension",
-    "version": "4.3.4",
+    "version": "4.3.5",
     "author": "Ton APPS UK Limited <support@tonkeeper.com>",
     "description": "Your extension wallet on The Open Network",
     "dependencies": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tonkeeper/mobile",
-    "version": "4.3.3",
+    "version": "4.3.5",
     "license": "Apache-2.0",
     "description": "Your tablet wallet on The Open Network",
     "type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tonkeeper/web",
-    "version": "4.3.4",
+    "version": "4.3.5",
     "author": "Ton APPS UK Limited <support@tonkeeper.com>",
     "description": "Your web wallet on The Open Network",
     "dependencies": {

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -4,7 +4,7 @@ import './i18n';
 
 import './telegram-widget';
 import { AppTgOauthRedirect, isInTgAuthInjectionContext } from "./AppTgOauthRedirect";
-import { getTgAuthResult } from "@tonkeeper/core/dist/service/telegramOauth";
+import { getTgAuthResult, sendTgAuthResultToOpener } from "@tonkeeper/core/dist/service/telegramOauth";
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
@@ -16,7 +16,7 @@ try {
   if (tgAuthResult) {
     if (isInTgAuthInjectionContext()) {
       EntryPoint = <AppTgOauthRedirect tgAuthResult={tgAuthResult} />;
-    } else {
+    } else if (!sendTgAuthResultToOpener(tgAuthResult)) {
       history.replaceState(null, '', window.location.pathname + window.location.search);
     }
   }

--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -17,6 +17,11 @@ export default defineConfig({
         react(),
         injectCSP(metaTagCspConfig)
     ],
+    server: {
+        // Required for local development to test Telegram OAuth callbacks.
+        // Vite rejects requests with Host header different from localhost by default.
+        allowedHosts: ['wallet.tonkeeper.com']
+    },
     resolve: {
         alias: {
             react: path.resolve(__dirname, './node_modules/react'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tonkeeper-web",
-    "version": "4.3.4",
+    "version": "4.3.5",
     "repository": {
         "type": "git",
         "url": "https://github.com/tonkeeper/tonkeeper-web.git"

--- a/packages/core/src/pro/models/SubscriptionVerification.ts
+++ b/packages/core/src/pro/models/SubscriptionVerification.ts
@@ -10,6 +10,10 @@ export type SubscriptionVerification = {
     /**
      * @deprecated
      */
+    project_id: number;
+    /**
+     * @deprecated
+     */
     is_trial: boolean;
     /**
      * @deprecated
@@ -18,7 +22,6 @@ export type SubscriptionVerification = {
     next_charge?: number;
     auth_token: string;
     tron_free_transfers: number;
-    project_id?: number;
     source: SubscriptionSource;
     crypto?: {
         amount: string;

--- a/packages/core/src/pro/services/TiersService.ts
+++ b/packages/core/src/pro/services/TiersService.ts
@@ -38,11 +38,13 @@ export class TiersService {
     }
     /**
      * Activate Pro trial subscription
+     * @param authorization
      * @param requestBody Data that is expected
      * @returns Ok Ok
      * @throws ApiError
      */
     public static activateTrial(
+        authorization: string,
         requestBody?: {
             id: number;
             first_name?: string;
@@ -56,6 +58,9 @@ export class TiersService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/services/pro/trial',
+            headers: {
+                'Authorization': authorization,
+            },
             body: requestBody,
             mediaType: 'application/json',
             errors: {

--- a/packages/core/src/service/proService.ts
+++ b/packages/core/src/service/proService.ts
@@ -208,14 +208,18 @@ export const saveIapPurchase = async (
     }
 };
 
-export async function startProServiceTrial(botId: string, lang?: string): Promise<string> {
+export async function startProServiceTrial(
+    botId: string,
+    token: string,
+    lang?: string
+): Promise<string> {
     const tgData = await loginViaTG(botId, lang);
 
     if (!tgData) {
         throw new Error('Unable to activate Trial');
     }
 
-    const result = await TiersService.activateTrial(tgData);
+    const result = await TiersService.activateTrial(`Bearer ${token}`, tgData);
 
     if (!result.ok || !result.auth_token) {
         throw new Error('Unable to activate Trial');

--- a/packages/core/src/service/telegramOauth.ts
+++ b/packages/core/src/service/telegramOauth.ts
@@ -89,3 +89,32 @@ export function getTgAuthResult(): string | false {
         return false;
     }
 }
+
+/**
+ * Sends Telegram OAuth result to the opener window via postMessage.
+ * Used in popup OAuth flow on web and desktop platforms.
+ * Mobile uses a different mechanism (Native Bridge + CustomEvent).
+ *
+ * @param tgAuthResult - Base64 encoded string with auth data from URL hash
+ * @returns true if successfully sent and window closed, false if no opener or error
+ */
+export function sendTgAuthResultToOpener(tgAuthResult: string): boolean {
+    const currentWindow = getWindow();
+
+    if (!currentWindow?.opener) {
+        return false;
+    }
+
+    try {
+        const authData: TGLoginData = JSON.parse(atob(tgAuthResult));
+        currentWindow.opener.postMessage(
+            JSON.stringify({ event: 'auth_result', result: authData }),
+            '*'
+        );
+        currentWindow.close();
+        return true;
+    } catch (e) {
+        console.error('Failed to send tg auth result to opener', e);
+        return false;
+    }
+}

--- a/packages/uikit/src/state/pro.ts
+++ b/packages/uikit/src/state/pro.ts
@@ -393,7 +393,12 @@ export const useActivateTrialMutation = () => {
             throw new Error('Pro trial tg bot id is not set');
         }
 
-        const token = await startProServiceTrial(config.pro_trial_tg_bot_id, language);
+        const authToken = await sdk.subscriptionService.getToken();
+        if (!authToken) {
+            throw new Error('Auth token is required for trial activation');
+        }
+
+        const token = await startProServiceTrial(config.pro_trial_tg_bot_id, authToken, language);
 
         await sdk.subscriptionService.activateTrial(token);
         await client.invalidateQueries([QueryKey.pro]);

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -49,7 +49,8 @@ apps.forEach(app => {
     if (
         app === 'desktop' ||
         app === 'extension' ||
-        app === 'web'
+        app === 'web' ||
+        app === 'mobile'
     ) {
         updatePackageVersion(path.join(appsDir, app));
     } else {


### PR DESCRIPTION
## Problem
After Telegram OAuth redirect, popup window with `tgAuthResult` didn't send data back to opener via postMessage. This caused "Telegram connection failed" error. Also, trial activation endpoint was failing with "public_key required" due to missing authorization header.

## Changes

### OAuth postMessage fix
- Add `sendTgAuthResultToOpener()` to `@tonkeeper/core` (shared between web and desktop)
- Use the function in web/desktop entry points to send auth result via postMessage
- Add comment explaining `allowedHosts` in vite.config.mts
- Add comment explaining why `withCredentials = false` in desktop telegram-widget.js (Electron manages cookies separately)

### Trial activation fix
- Add authorization header to `/api/v1/services/pro/trial` endpoint
- Pass auth token from `subscriptionService.getToken()` to `TiersService.activateTrial()`

### CI fix
- Migrate macOS runners from deprecated `macos-13` to `macos-15-intel` (x64) and `macos-latest` (arm64/universal)

## Status
- ✅ Web: tested, OAuth works
- ✅ Desktop: tested, OAuth works