### PR TITLE
fix(tonconnect): exclude undefined stateInit from proof response

### DIFF
--- a/packages/core/src/service/tonConnect/connectService.ts
+++ b/packages/core/src/service/tonConnect/connectService.ts
@@ -431,8 +431,8 @@ export const createTonProofItem = (
             value: proof.domainBuffer.toString('utf8') // app domain name (as url part, without encoding)
         },
         signature: Buffer.from(signature).toString('base64'), // base64-encoded signature
-        payload: proof.payload, // payload from the request,
-        stateInit: stateInit // state init for a wallet
+        payload: proof.payload, // payload from the request
+        ...(stateInit !== undefined && { stateInit }) // state init for a wallet (only if defined)
     };
 };
 


### PR DESCRIPTION
## Summary
- Fix `stateInit: undefined` appearing in TonConnect proof response in Firefox extension
- Conditionally add `stateInit` only when defined

## Problem
Firefox preserves `undefined` values during `postMessage` serialization, causing TonConnect SDK to see `stateInit: undefined` instead of the field being absent.

## Solution
Use spread operator to conditionally include `stateInit` only when it's defined.

Fixes PRO-404