### PR TITLE
fix(tonconnect): use 'browser' platform for extension

### DIFF
--- a/apps/extension/src/libs/service/dApp/tonConnectService.ts
+++ b/apps/extension/src/libs/service/dApp/tonConnectService.ts
@@ -13,6 +13,7 @@ import {
     checkTonConnectFromAndNetwork,
     getDeviceInfo,
     getInjectedDappConnection,
+    getTonConnectPlatform,
     tonConnectTonkeeperAppName,
     tonInjectedDisconnectRequest,
     tonInjectedReConnectRequest
@@ -38,12 +39,10 @@ const tonReConnectResponse = async (origin: string): Promise<TonConnectEventPayl
     };
 };
 
-export function getExtensionDeviceInfo(options?: {
-    maxMessages?: number;
-}): DeviceInfo {
+export function getExtensionDeviceInfo(options?: { maxMessages?: number }): DeviceInfo {
     const { version } = browser.runtime.getManifest();
     return getDeviceInfo(
-        'browser',
+        getTonConnectPlatform('extension'),
         version,
         options?.maxMessages ?? 255,
         tonConnectTonkeeperAppName

--- a/apps/extension/src/libs/service/dApp/tonConnectService.ts
+++ b/apps/extension/src/libs/service/dApp/tonConnectService.ts
@@ -29,43 +29,21 @@ import { showNotificationInPopup } from '../backgroundPopUpService';
 
 const storage = new ExtensionStorage();
 
-const getTonConnectPlatform = (os: browser.Runtime.PlatformOs): DeviceInfo['platform'] => {
-    switch (os) {
-        case 'mac': {
-            return 'mac';
-        }
-        case 'win': {
-            return 'windows';
-        }
-        case 'android': {
-            return 'android';
-        }
-        case 'cros':
-        case 'linux':
-        case 'openbsd': {
-            return 'linux';
-        }
-        default:
-            return '' as unknown as DeviceInfo['platform'];
-    }
-};
-
 const tonReConnectResponse = async (origin: string): Promise<TonConnectEventPayload> => {
     const { items, maxMessages } = await tonInjectedReConnectRequest(storage, origin);
 
     return {
         items,
-        device: await getExtensionDeviceInfo({ maxMessages })
+        device: getExtensionDeviceInfo({ maxMessages })
     };
 };
 
-export async function getExtensionDeviceInfo(options?: {
+export function getExtensionDeviceInfo(options?: {
     maxMessages?: number;
-}): Promise<DeviceInfo> {
+}): DeviceInfo {
     const { version } = browser.runtime.getManifest();
-    const { os } = await browser.runtime.getPlatformInfo();
     return getDeviceInfo(
-        getTonConnectPlatform(os),
+        'browser',
         version,
         options?.maxMessages ?? 255,
         tonConnectTonkeeperAppName

--- a/apps/extension/src/provider/tonconnect.ts
+++ b/apps/extension/src/provider/tonconnect.ts
@@ -16,6 +16,7 @@ import {
 import { TonProvider } from '../provider/index';
 import {
     getDeviceInfo,
+    getTonConnectPlatform,
     tonConnectTonkeeperAppName,
     tonConnectTonkeeperWalletInfo
 } from '@tonkeeper/core/dist/service/tonConnect/connectService';
@@ -40,7 +41,12 @@ export class ExtensionTonConnectInjectedBridge implements ITonConnectInjectedBri
 
     walletInfo = tonConnectTonkeeperWalletInfo;
 
-    deviceInfo = getDeviceInfo('browser', packageJson.version, 255, tonConnectTonkeeperAppName);
+    deviceInfo = getDeviceInfo(
+        getTonConnectPlatform('extension'),
+        packageJson.version,
+        255,
+        tonConnectTonkeeperAppName
+    );
 
     protocolVersion = tonConnectProtocolVersion;
 

--- a/apps/mobile/src/inject-scripts/ton-connect.ts
+++ b/apps/mobile/src/inject-scripts/ton-connect.ts
@@ -9,8 +9,8 @@ import type {
     WalletResponse
 } from '@tonkeeper/core/dist/entries/tonConnect';
 import {
-    getBrowserPlatform,
     getDeviceInfo,
+    getTonConnectPlatform,
     tonConnectTonkeeperProAppName,
     tonConnectTonkeeperProWalletInfo
 } from '@tonkeeper/core/dist/service/tonConnect/connectService';
@@ -20,7 +20,7 @@ import { NATIVE_BRIDGE_METHODS } from './native-bridge-methods';
 
 function currentDeviceInfo(options?: { maxMessages?: number }): DeviceInfo {
     return getDeviceInfo(
-        getBrowserPlatform(),
+        getTonConnectPlatform('mobile'),
         packageJson.version,
         options?.maxMessages ?? 255,
         tonConnectTonkeeperProAppName

--- a/apps/mobile/src/libs/ton-connect/capacitor-injected-connector.ts
+++ b/apps/mobile/src/libs/ton-connect/capacitor-injected-connector.ts
@@ -28,9 +28,9 @@ import { capacitorStorage } from '../appSdk';
 import {
     checkTonConnectFromAndNetwork,
     disconnectResponse,
-    getBrowserPlatform,
     getDeviceInfo,
     getInjectedDappConnection,
+    getTonConnectPlatform,
     tonConnectTonkeeperProAppName,
     tonInjectedReConnectRequest
 } from '@tonkeeper/core/dist/service/tonConnect/connectService';
@@ -153,7 +153,7 @@ class CapacitorTonConnectInjectedConnector {
                         payload: {
                             items,
                             device: getDeviceInfo(
-                                getBrowserPlatform(),
+                                getTonConnectPlatform('mobile'),
                                 packageJson.version,
                                 maxMessages,
                                 tonConnectTonkeeperProAppName

--- a/packages/core/src/service/tonConnect/connectService.ts
+++ b/packages/core/src/service/tonConnect/connectService.ts
@@ -1,6 +1,7 @@
 import { Address, beginCell, storeStateInit } from '@ton/core';
 import { getSecureRandomBytes, keyPairFromSeed, sha256_sync } from '@ton/crypto';
 import queryString from 'query-string';
+import { TargetEnv } from '../../AppSdk';
 import { IStorage } from '../../Storage';
 import { TonConnectError } from '../../entries/exception';
 import { Network } from '../../entries/network';
@@ -188,6 +189,13 @@ export function getBrowserPlatform(): DeviceInfo['platform'] {
     }
 
     return os!;
+}
+
+export function getTonConnectPlatform(targetEnv: TargetEnv): DeviceInfo['platform'] {
+    if (targetEnv === 'extension') {
+        return 'browser';
+    }
+    return getBrowserPlatform();
 }
 
 export const getDeviceInfo = (

--- a/packages/core/src/service/tonConnect/connectService.ts
+++ b/packages/core/src/service/tonConnect/connectService.ts
@@ -160,7 +160,7 @@ export const getManifest = async (request: ConnectRequest) => {
     return manifest;
 };
 
-export function getBrowserPlatform(): DeviceInfo['platform'] {
+function getBrowserPlatform(): DeviceInfo['platform'] {
     const platform =
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (window?.navigator as any)?.userAgentData?.platform || window?.navigator.platform;

--- a/packages/uikit/src/components/connect/TonConnectNotification.tsx
+++ b/packages/uikit/src/components/connect/TonConnectNotification.tsx
@@ -7,9 +7,9 @@ import {
 } from '@tonkeeper/core/dist/entries/tonConnect';
 import {
     checkDappOriginMatchesManifest,
-    getBrowserPlatform,
     getDeviceInfo,
-    getManifest
+    getManifest,
+    getTonConnectPlatform
 } from '@tonkeeper/core/dist/service/tonConnect/connectService';
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
@@ -150,9 +150,7 @@ const ConnectContent: FC<{
                         replyItems: {
                             items: replyItems,
                             device: getDeviceInfo(
-                                sdk.targetEnv === 'extension'
-                                    ? 'browser'
-                                    : getBrowserPlatform(),
+                                getTonConnectPlatform(sdk.targetEnv),
                                 sdk.version,
                                 maxMessages,
                                 appName

--- a/packages/uikit/src/components/connect/TonConnectNotification.tsx
+++ b/packages/uikit/src/components/connect/TonConnectNotification.tsx
@@ -150,7 +150,9 @@ const ConnectContent: FC<{
                         replyItems: {
                             items: replyItems,
                             device: getDeviceInfo(
-                                getBrowserPlatform(),
+                                sdk.targetEnv === 'extension'
+                                    ? 'browser'
+                                    : getBrowserPlatform(),
                                 sdk.version,
                                 maxMessages,
                                 appName


### PR DESCRIPTION
## Summary
- Add centralized `getTonConnectPlatform(targetEnv)` function for TonConnect DeviceInfo platform
- Extension returns `'browser'`, other environments use browser detection
- Make `getBrowserPlatform` private (internal use only)

## Changes
- **core**: Add `getTonConnectPlatform()` in `connectService.ts`
- **uikit**: Use `getTonConnectPlatform(sdk.targetEnv)` in `TonConnectNotification`
- **extension**: Use `getTonConnectPlatform('extension')` in both TonConnect files
- **mobile**: Use `getTonConnectPlatform('mobile')` for consistency

## Why
Platform determination was duplicated and inconsistent. Now there's a single source of truth.

Fixes PRO-411