### PR TITLE
Show user-friendly error when TronGrid is unavailable

### DIFF
--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -17,6 +17,9 @@ export default defineConfig({
         react(),
         injectCSP(metaTagCspConfig)
     ],
+    server: {
+        allowedHosts: ['wallet.tonkeeper.com'],
+    },
     resolve: {
         alias: {
             react: path.resolve(__dirname, './node_modules/react'),

--- a/packages/core/src/errors/TronApiHttpError.ts
+++ b/packages/core/src/errors/TronApiHttpError.ts
@@ -1,0 +1,14 @@
+import { TranslatableError } from './TranslatableError';
+
+export class TronApiHttpError extends Error implements TranslatableError {
+    public readonly translate = 'trc20_transfer_unavailable';
+
+    constructor(public readonly status: number, message?: string) {
+        super(message ?? `TronGrid HTTP error ${status}`);
+        this.name = 'TronApiHttpError';
+    }
+
+    get isRateLimit() {
+        return this.status === 429;
+    }
+}

--- a/packages/locales/src/tonkeeper/en.json
+++ b/packages/locales/src/tonkeeper/en.json
@@ -228,6 +228,7 @@
   "select_wallet_for_authorization": "Select Wallet for authorization",
   "send_fee_estimation_error": "Failed to calculate fee",
   "send_publish_tx_error": "Failed to send transaction",
+  "trc20_transfer_unavailable": "Sending TRC20 is temporarily unavailable",
   "send_screen_steps": {
     "address": {
       "delete_alert_text": "Are you sure want to delete «{name}» from your favorites?",

--- a/packages/locales/src/tonkeeper/ru-RU.json
+++ b/packages/locales/src/tonkeeper/ru-RU.json
@@ -228,6 +228,7 @@
   "select_wallet_for_authorization": "Выберите кошелёк для авторизации",
   "send_fee_estimation_error": "Ошибка подсчёта комиссии",
   "send_publish_tx_error": "Ошибка публикации транзакции",
+  "trc20_transfer_unavailable": "Отправка TRC20 временно недоступна",
   "send_screen_steps": {
     "address": {
       "delete_alert_text": "Вы точно хотите удалить «{name}» из избранного?",

--- a/packages/uikit/src/hooks/blockchain/useEstimateTransfer.ts
+++ b/packages/uikit/src/hooks/blockchain/useEstimateTransfer.ts
@@ -110,10 +110,10 @@ export function useEstimateTransfer({
             }
         },
         {
-            refetchInterval: DefaultRefetchInterval,
+            refetchInterval: isTronAsset(amount.asset) ? false : DefaultRefetchInterval,
             refetchOnMount: 'always',
             enabled: !!getSender && senderType !== undefined,
-            retry: 2
+            retry: isTronAsset(amount.asset) ? false : 2
         }
     );
 }

--- a/packages/uikit/src/state/activity.ts
+++ b/packages/uikit/src/state/activity.ts
@@ -218,6 +218,9 @@ export const useFetchFilteredActivity = (assetAddress?: string) => {
                           onlyInitiator,
                           filterSpam,
                           batteryAuthToken: batteryAuthToken ?? undefined
+                      }).catch(e => {
+                          console.error('Tron activity fetch failed:', e);
+                          return emptyResult;
                       })
             ]);
 

--- a/packages/uikit/src/state/tron/tron.ts
+++ b/packages/uikit/src/state/tron/tron.ts
@@ -156,7 +156,8 @@ export const useTronBalances = () => {
             refetchInterval: DefaultRefetchInterval,
             refetchIntervalInBackground: true,
             refetchOnWindowFocus: true,
-            keepPreviousData: true
+            keepPreviousData: true,
+            retry: false
         }
     );
 };
@@ -215,11 +216,14 @@ export const useTrc20FreeTransfersConfig = () => {
 const useTrc20TrxDefaultFee = () => {
     const tronApi = useTronApi();
 
-    return useQuery([QueryKey.trc20TrxDefaultFee], () =>
-        TronTrxSender.getBurnTrxAmountForResources(
-            tronApi,
-            TronTrc20Encoder.transferDefaultResources
-        )
+    return useQuery(
+        [QueryKey.trc20TrxDefaultFee],
+        () =>
+            TronTrxSender.getBurnTrxAmountForResources(
+                tronApi,
+                TronTrc20Encoder.transferDefaultResources
+            ),
+        { retry: false }
     );
 };
 


### PR DESCRIPTION
Reduce TronGrid API calls — compute sender fees locally instead of calling `estimate()` per sender type.                                           
                  
Show "Sending TRC20 is temporarily unavailable" instead of misleading "Insufficient funds" when TronGrid is down or rate-limited.

Details: TK-59