### PR TITLE
fix(swap): various UX improvements for omniston swaps

### DIFF
--- a/packages/core/src/swapsApi/SwapService.ts
+++ b/packages/core/src/swapsApi/SwapService.ts
@@ -8,6 +8,8 @@ export async function fetchSwapAssets(baseUrl: string): Promise<SwapAsset[]> {
     return response.json();
 }
 
+const QUOTE_TIMEOUT_MS = 10_000;
+
 export function subscribeToOmnistonStream(params: {
     baseUrl: string;
     fromAsset: string;
@@ -29,22 +31,32 @@ export function subscribeToOmnistonStream(params: {
     }
 
     const eventSource = new EventSource(url.toString());
+    let quoteTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
     const onMessage = (event: MessageEvent<string>) => {
         try {
             const data = JSON.parse(event.data);
 
             if (data.type === 'connected') {
+                quoteTimeoutId = setTimeout(() => {
+                    close();
+                    params.onError(new Error('Quote request timed out'));
+                }, QUOTE_TIMEOUT_MS);
                 return;
             }
 
+            clearTimeout(quoteTimeoutId);
+
             if (data.error) {
+                close();
                 params.onError(new Error(data.error));
                 return;
             }
 
             params.onQuote(data as SwapConfirmation);
         } catch (e) {
+            clearTimeout(quoteTimeoutId);
+            close();
             params.onError(e instanceof Error ? e : new Error('Failed to parse SSE message'));
         }
     };
@@ -58,6 +70,7 @@ export function subscribeToOmnistonStream(params: {
     eventSource.addEventListener('error', onError);
 
     const close = () => {
+        clearTimeout(quoteTimeoutId);
         eventSource.removeEventListener('message', onMessage);
         eventSource.removeEventListener('error', onError);
         eventSource.close();

--- a/packages/locales/src/tonkeeper/ar.json
+++ b/packages/locales/src/tonkeeper/ar.json
@@ -324,6 +324,7 @@
     "subtitle": "قد يكون الـNFT غير آمن للاستخدام بسبب أحد الأسباب التالية.",
     "title": "لم يتم التحقق منه NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "لا يوجد TON كافٍ لرسوم الشبكة ({required})",
   "swap_exchange_in": "التبادل في",
   "swap_expired_refresh": "انتهت صلاحية المبادلة. حدّث عرض السعر",
   "swap_price_impact_description": "الفرق بين سعر السوق والسعر المقدر بسبب حجم الصفقة.",

--- a/packages/locales/src/tonkeeper/bg.json
+++ b/packages/locales/src/tonkeeper/bg.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT може да не е безопасно за използване по една от следните причини.",
     "title": "Непроверено NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "Недостатъчно TON за мрежова такса ({required})",
   "swap_exchange_in": "Обмяна в",
   "swap_expired_refresh": "Обменът изтече. Обновете офертата",
   "swap_price_impact_description": "Разликата между пазарната цена и прогнозната цена поради размера на сделката.",

--- a/packages/locales/src/tonkeeper/bn.json
+++ b/packages/locales/src/tonkeeper/bn.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT ব্যবহার নিরাপদ নাও হতে পারে নিম্নলিখিত কারণে।",
     "title": "অবৈধ NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "নেটওয়ার্ক ফি এর জন্য পর্যাপ্ত TON নেই ({required})",
   "swap_exchange_in": "এক্সচেঞ্জ ইন",
   "swap_expired_refresh": "সোয়াপ মেয়াদ শেষ। কোট রিফ্রেশ করুন",
   "swap_price_impact_description": "বাণিজ্যের আকারের কারণে বাজার মূল্য এবং আনুমানিক মূল্যের মধ্যে পার্থক্য।",

--- a/packages/locales/src/tonkeeper/de.json
+++ b/packages/locales/src/tonkeeper/de.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT ist möglicherweise aus einem der folgenden Gründe nicht sicher zu verwenden.",
     "title": "Unverifiziertes NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "Nicht genug TON für Netzwerkgebühr ({required})",
   "swap_exchange_in": "Tausch in",
   "swap_expired_refresh": "Swap abgelaufen. Kurs aktualisieren",
   "swap_price_impact_description": "Die Differenz zwischen dem Marktpreis und dem geschätzten Preis aufgrund der Handelsgröße.",

--- a/packages/locales/src/tonkeeper/en.json
+++ b/packages/locales/src/tonkeeper/en.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT may not be safe to use for one of the following reasons.",
     "title": "Unverified NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "Not enough TON for network fee ({required})",
   "swap_exchange_in": "Exchange in",
   "swap_expired_refresh": "Swap expired. Refresh the quote",
   "swap_price_impact_description": "The difference between the market price and estimated price due to trade size.",

--- a/packages/locales/src/tonkeeper/es.json
+++ b/packages/locales/src/tonkeeper/es.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT puede no ser seguro por una de las siguientes razones.",
     "title": "NFT no verificado"
   },
+  "swap_confirm_not_enough_ton_for_fee": "TON insuficiente para comisión de red ({required})",
   "swap_exchange_in": "Intercambiar en",
   "swap_expired_refresh": "Intercambio caducado. Actualiza la cotización",
   "swap_price_impact_description": "La diferencia entre el precio de mercado y el precio estimado debido al tamaño de la operación.",

--- a/packages/locales/src/tonkeeper/fa.json
+++ b/packages/locales/src/tonkeeper/fa.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT ممکن است به یکی از دلایل زیر امن نباشد.",
     "title": "NFT تاییدنشده"
   },
+  "swap_confirm_not_enough_ton_for_fee": "TON کافی برای کارمزد شبکه وجود ندارد ({required})",
   "swap_exchange_in": "تبادل در",
   "swap_expired_refresh": "مبادله منقضی شد. قیمت را بروزرسانی کنید",
   "swap_price_impact_description": "تفاوت بین قیمت بازار و قیمت تخمینی به دلیل حجم معامله.",

--- a/packages/locales/src/tonkeeper/fr.json
+++ b/packages/locales/src/tonkeeper/fr.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT peut ne pas être sûr à utiliser pour l'une des raisons suivantes.",
     "title": "NFT non vérifié"
   },
+  "swap_confirm_not_enough_ton_for_fee": "TON insuffisant pour les frais de réseau ({required})",
   "swap_exchange_in": "Échanger en",
   "swap_expired_refresh": "Swap expiré. Actualiser le devis",
   "swap_price_impact_description": "La différence entre le prix du marché et le prix estimé en raison de la taille de la transaction.",

--- a/packages/locales/src/tonkeeper/hi.json
+++ b/packages/locales/src/tonkeeper/hi.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT may not be safe to use for one of the following reasons.",
     "title": "Unverified NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "नेटवर्क शुल्क के लिए पर्याप्त TON नहीं है ({required})",
   "swap_exchange_in": "एक्सचेंज इन",
   "swap_expired_refresh": "स्वैप समाप्त हो गया। कोट रिफ्रेश करें",
   "swap_price_impact_description": "व्यापार आकार के कारण बाजार मूल्य और अनुमानित मूल्य के बीच का अंतर।",

--- a/packages/locales/src/tonkeeper/id.json
+++ b/packages/locales/src/tonkeeper/id.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT mungkin tidak aman digunakan karena salah satu dari alasan berikut.",
     "title": "NFT yang belum diverifikasi"
   },
+  "swap_confirm_not_enough_ton_for_fee": "TON tidak cukup untuk biaya jaringan ({required})",
   "swap_exchange_in": "Tukar masuk",
   "swap_expired_refresh": "Swap kedaluwarsa. Perbarui kuotasi",
   "swap_price_impact_description": "Perbedaan antara harga pasar dan perkiraan harga karena ukuran transaksi.",

--- a/packages/locales/src/tonkeeper/it.json
+++ b/packages/locales/src/tonkeeper/it.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT potrebbe non essere sicuro da utilizzare per uno dei seguenti motivi.",
     "title": "NFT non verificato"
   },
+  "swap_confirm_not_enough_ton_for_fee": "TON insufficienti per la commissione di rete ({required})",
   "swap_exchange_in": "Scambia in",
   "swap_expired_refresh": "Swap scaduto. Aggiorna la quotazione",
   "swap_price_impact_description": "La differenza tra il prezzo di mercato e il prezzo stimato dovuta alla dimensione dello scambio.",

--- a/packages/locales/src/tonkeeper/pa.json
+++ b/packages/locales/src/tonkeeper/pa.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT ਹੇਠਾਂ ਦਿੱਤੇ ਕਾਰਣਾਂ ਵਿਚੋਂ ਕਿਸੇ ਇੱਕ ਕਾਰਨ ਕਰਕੇ ਸੁਰੱਖਿਅਤ ਨਹੀਂ ਹੋ ਸਕਦਾ.",
     "title": "ਗੈਰ-ਤਸਦੀਕਸ਼ੁਦਾ NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "ਨੈੱਟਵਰਕ ਫੀਸ ਲਈ ਕਾਫ਼ੀ TON ਨਹੀਂ ({required})",
   "swap_exchange_in": "ਵਿੱਚ ਐਕਸਚੇਂਜ",
   "swap_expired_refresh": "ਸਵੈਪ ਦੀ ਮਿਆਦ ਖਤਮ ਹੋ ਗਈ। ਕੋਟ ਨੂੰ ਤਾਜ਼ਾ ਕਰੋ",
   "swap_price_impact_description": "ਵਪਾਰ ਦੇ ਆਕਾਰ ਕਾਰਨ ਮਾਰਕੀਟ ਕੀਮਤ ਅਤੇ ਅਨੁਮਾਨਿਤ ਕੀਮਤ ਵਿਚਕਾਰ ਅੰਤਰ।",

--- a/packages/locales/src/tonkeeper/pt.json
+++ b/packages/locales/src/tonkeeper/pt.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT pode não ser seguro para uso por um dos seguintes motivos.",
     "title": "NFT não verificado"
   },
+  "swap_confirm_not_enough_ton_for_fee": "TON insuficiente para taxa de rede ({required})",
   "swap_exchange_in": "Trocar em",
   "swap_expired_refresh": "Swap expirou. Atualize a cotação",
   "swap_price_impact_description": "A diferença entre o preço de mercado e o preço estimado devido ao tamanho da negociação.",

--- a/packages/locales/src/tonkeeper/ru-RU.json
+++ b/packages/locales/src/tonkeeper/ru-RU.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT может быть небезопасным по одной из следующих причин.",
     "title": "Непроверенный NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "Недостаточно TON для комиссии сети ({required})",
   "swap_exchange_in": "Обменять в",
   "swap_expired_refresh": "Своп истёк. Обновите котировку",
   "swap_price_impact_description": "Разница между рыночной ценой и расчётной ценой из-за размера сделки.",

--- a/packages/locales/src/tonkeeper/tr-TR.json
+++ b/packages/locales/src/tonkeeper/tr-TR.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT aşağıdaki nedenlerden biri nedeniyle güvenli olmayabilir.",
     "title": "Doğrulanmamış NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "Ağ ücreti için yeterli TON yok ({required})",
   "swap_exchange_in": "Takas giriş",
   "swap_expired_refresh": "Takas süresi doldu. Fiyat teklifini yenile",
   "swap_price_impact_description": "İşlem büyüklüğü nedeniyle piyasa fiyatı ile tahmini fiyat arasındaki fark.",

--- a/packages/locales/src/tonkeeper/uk.json
+++ b/packages/locales/src/tonkeeper/uk.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT може бути небезпечним з однієї з наступних причин.",
     "title": "Неперевірений NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "Недостатньо TON для комісії мережі ({required})",
   "swap_exchange_in": "Обміняти в",
   "swap_expired_refresh": "Своп закінчився. Оновіть котирування",
   "swap_price_impact_description": "Різниця між ринковою ціною та розрахунковою ціною через розмір угоди.",

--- a/packages/locales/src/tonkeeper/uz.json
+++ b/packages/locales/src/tonkeeper/uz.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT quyidagi sabablardan biri uchun xavfsiz bo'lmasligi mumkin.",
     "title": "Tasdiqlanmagan NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "Tarmoq to'lovi uchun TON yetarli emas ({required})",
   "swap_exchange_in": "Almashtirish",
   "swap_expired_refresh": "Swap muddati tugadi. Kotirovkani yangilang",
   "swap_price_impact_description": "Savdo hajmi tufayli bozor narxi va taxminiy narx o'rtasidagi farq.",

--- a/packages/locales/src/tonkeeper/vi.json
+++ b/packages/locales/src/tonkeeper/vi.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT có thể không an toàn để sử dụng vì một trong những lý do sau.",
     "title": "NFT chưa được xác minh"
   },
+  "swap_confirm_not_enough_ton_for_fee": "Không đủ TON để trả phí mạng ({required})",
   "swap_exchange_in": "Hoán đổi trong",
   "swap_expired_refresh": "Giao dịch đã hết hạn. Làm mới báo giá",
   "swap_price_impact_description": "Chênh lệch giữa giá thị trường và giá ước tính do quy mô giao dịch.",

--- a/packages/locales/src/tonkeeper/zh-Hans-CN.json
+++ b/packages/locales/src/tonkeeper/zh-Hans-CN.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT 可能因以下原因之一而不安全。",
     "title": "未验证的NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "TON 不足以支付网络费用（{required}）",
   "swap_exchange_in": "兑换",
   "swap_expired_refresh": "兑换已过期。刷新报价",
   "swap_price_impact_description": "由于交易规模导致的市场价格与预估价格之间的差异。",

--- a/packages/locales/src/tonkeeper/zh-Hant.json
+++ b/packages/locales/src/tonkeeper/zh-Hant.json
@@ -324,6 +324,7 @@
     "subtitle": "NFT 可能因以下原因之一而不安全使用。",
     "title": "未驗證的NFT"
   },
+  "swap_confirm_not_enough_ton_for_fee": "TON 不足以支付網絡費用 ({required})",
   "swap_exchange_in": "兌換",
   "swap_expired_refresh": "交換已過期。重新整理報價",
   "swap_price_impact_description": "由於交易規模導致市場價格與預估價格之間的差異。",

--- a/packages/uikit/src/components/swap/SwapConfirmationNotification.tsx
+++ b/packages/uikit/src/components/swap/SwapConfirmationNotification.tsx
@@ -30,7 +30,7 @@ import {
     useTonConnectAvailableSendersChoices
 } from '../../hooks/blockchain/useSender';
 import { useTonConnectTransactionService } from '../../hooks/blockchain/useBlockchainService';
-import { useActiveAccount } from '../../state/wallet';
+import { useActiveAccount, useTonBalance } from '../../state/wallet';
 import { useBatteryUnitTonRate } from '../../state/battery';
 import { useRate } from '../../state/rates';
 import {
@@ -243,9 +243,11 @@ const SwapConfirmContent: FC<{
 
     // --- Fee ---
     const batteryUnitTonRate = useBatteryUnitTonRate();
+    const gasExtra = useMemo(
+        () => new AssetAmount({ asset: TON_ASSET, weiAmount: confirmation.gasBudget }),
+        [confirmation.gasBudget]
+    );
     const fee: TransactionFee = useMemo(() => {
-        const gasExtra = new AssetAmount({ asset: TON_ASSET, weiAmount: confirmation.gasBudget });
-
         if (selectedSenderType === BATTERY_SENDER_CHOICE.type) {
             return {
                 type: 'battery',
@@ -257,7 +259,25 @@ const SwapConfirmContent: FC<{
         }
 
         return { type: 'ton-asset', extra: gasExtra };
-    }, [confirmation.gasBudget, selectedSenderType, batteryUnitTonRate]);
+    }, [gasExtra, selectedSenderType, batteryUnitTonRate]);
+
+    // --- TON balance check for external sender ---
+    const { data: tonBalance } = useTonBalance();
+    const totalTonRequired = useMemo(
+        () =>
+            new AssetAmount({
+                asset: TON_ASSET,
+                weiAmount: payload.messages.reduce(
+                    (acc, msg) => acc.plus(msg.amount),
+                    new BigNumber(0)
+                )
+            }),
+        [payload.messages]
+    );
+    const insufficientTonForFee =
+        selectedSenderType === EXTERNAL_SENDER_CHOICE.type &&
+        tonBalance !== undefined &&
+        totalTonRequired.isGT(tonBalance);
 
     // --- Slippage ---
     const slippagePercent = useMemo(
@@ -466,6 +486,12 @@ const SwapConfirmContent: FC<{
                     ) : isExpired ? (
                         <Button size="small" fullWidth type="button" onClick={() => handleClose()}>
                             {t('swap_expired_refresh')}
+                        </Button>
+                    ) : insufficientTonForFee ? (
+                        <Button size="small" fullWidth type="button" disabled>
+                            {t('swap_confirm_not_enough_ton_for_fee', {
+                                required: totalTonRequired.stringAssetRelativeAmount
+                            })}
                         </Button>
                     ) : (
                         <Button

--- a/packages/uikit/src/components/swap/SwapConfirmationNotification.tsx
+++ b/packages/uikit/src/components/swap/SwapConfirmationNotification.tsx
@@ -49,6 +49,7 @@ import { ActionFeeDetailsUniversal } from '../activity/NotificationCommon';
 import { WalletEmoji } from '../shared/emoji/WalletEmoji';
 import { ConfirmOperationHeading } from '../confirm-modal/ConfirmOperationHeading';
 import { getErrorText } from '@tonkeeper/core/dist/errors/TranslatableError';
+import { UserCancelledError } from '@tonkeeper/core/dist/errors/UserCancelledError';
 
 const EXPIRE_BUFFER_SECONDS = 3;
 
@@ -290,6 +291,7 @@ const SwapConfirmContent: FC<{
             setTimeout(() => handleClose({ boc }), 300);
         } catch (e) {
             sdk.hapticNotification('error');
+            setTimeout(() => handleClose(), 3000);
             console.error(e);
         }
     }, [isAlmostExpired, isSending, mutateAsync, sdk, handleClose]);
@@ -449,7 +451,9 @@ const SwapConfirmContent: FC<{
             <NotificationFooterPortal>
                 <NotificationFooter>
                     <FooterGap />
-                    {sendError ? (
+                    {sendError &&
+                    !(sendError instanceof UserCancelledError) &&
+                    sendError.message !== 'Cancel auth request' ? (
                         <ResultButtonErrored>
                             <ExclamationMarkCircleIconStyled />
                             <Label2>{getErrorText(sendError, { t })}</Label2>

--- a/packages/uikit/src/desktop-pages/swap/index.tsx
+++ b/packages/uikit/src/desktop-pages/swap/index.tsx
@@ -19,6 +19,16 @@ import { ErrorBoundary } from '../../components/shared/ErrorBoundary';
 import { IfFeatureEnabled } from '../../components/shared/IfFeatureEnabled';
 import { FLAGGED_FEATURE } from '../../state/tonendpoint';
 
+const HeaderButtons = styled.div`
+    margin-left: auto;
+    display: flex;
+
+    > * {
+        color: ${p => p.theme.iconSecondary};
+        padding: 10px;
+    }
+`;
+
 const SwapPageWrapper = styled(DesktopViewPageLayout)`
     overflow-y: auto;
 
@@ -54,9 +64,9 @@ const DesktopSwapPageContent = () => {
                 <DesktopViewHeaderContent
                     title={t('wallet_swap')}
                     right={
-                        <DesktopViewHeaderContent.Right>
+                        <HeaderButtons>
                             <SwapSettingsButton />
-                        </DesktopViewHeaderContent.Right>
+                        </HeaderButtons>
                     }
                 />
             </DesktopViewHeader>

--- a/packages/uikit/src/state/swap/useSwapStreamEffect.ts
+++ b/packages/uikit/src/state/swap/useSwapStreamEffect.ts
@@ -38,6 +38,7 @@ export function useSwapStreamEffect() {
     const slippageBps = useSlippageBps();
     const closeRef = useRef<(() => void) | null>(null);
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const lastParamsRef = useRef<string | null>(null);
     const [, setConfirmation] = useAtom(swapConfirmation$);
     const [, setIsFetching] = useAtom(swapIsFetching$);
     const [, setError] = useAtom(swapError$);
@@ -49,6 +50,7 @@ export function useSwapStreamEffect() {
         }
 
         if (isNotCompleted || !fromAmountRelative) {
+            lastParamsRef.current = null;
             setConfirmation(null);
             setIsFetching(false);
             setError(null);
@@ -57,9 +59,15 @@ export function useSwapStreamEffect() {
 
         const fromAmountWei = unShiftedDecimals(fromAmountRelative, fromAsset.decimals);
 
+        const paramsKey = `${toTradeAssetId(fromAsset.address)}:${toTradeAssetId(toAsset.address)}:${fromAmountWei.toFixed(0)}:${slippageBps}:${wallet.rawAddress}`;
+        const isParamsChanged = lastParamsRef.current !== paramsKey;
+        lastParamsRef.current = paramsKey;
+
+        if (isParamsChanged) {
+            setConfirmation(null);
+        }
         setIsFetching(true);
         setError(null);
-        setConfirmation(null);
 
         const abortController = new AbortController();
 
@@ -75,7 +83,6 @@ export function useSwapStreamEffect() {
                 setIsFetching(false);
             },
             onError: error => {
-                setConfirmation(null);
                 setError(error);
                 setIsFetching(false);
             },
@@ -118,6 +125,29 @@ export function useSwapStreamEffect() {
             }
         };
     }, [subscribe]);
+
+    // Re-subscribe when app regains visibility or network
+    useEffect(() => {
+        const onResume = () => {
+            if (!isNotCompleted && fromAmountRelative) {
+                subscribe();
+            }
+        };
+
+        const onVisibilityChange = () => {
+            if (document.visibilityState === 'visible') {
+                onResume();
+            }
+        };
+
+        document.addEventListener('visibilitychange', onVisibilityChange);
+        window.addEventListener('online', onResume);
+
+        return () => {
+            document.removeEventListener('visibilitychange', onVisibilityChange);
+            window.removeEventListener('online', onResume);
+        };
+    }, [subscribe, isNotCompleted, fromAmountRelative]);
 }
 
 export function useSwapConfirmation() {


### PR DESCRIPTION
## Summary
- Disable confirm button when TON balance is insufficient for network fee
- Auto-close confirmation modal on cancel/error
- Preserve quote on background/offline and auto-reconnect on resume
- Add 10s timeout to SSE quote stream to prevent infinite loading
- Show settings button directly on iOS instead of three-dots menu