### PR TITLE
fix(uikit): apply pointer-events none to tooltip

### DIFF
--- a/packages/uikit/src/components/shared/Tooltip.tsx
+++ b/packages/uikit/src/components/shared/Tooltip.tsx
@@ -3,13 +3,15 @@ import { BorderSmallResponsive } from './Styles';
 import { Body3Class } from '../Text';
 
 export const Tooltip = styled.div<{ placement: 'top' | 'bottom' }>`
+    && {
+        pointer-events: none;
+    }
     transform: translate3d(0, -10px, 0);
     z-index: 100;
     left: 0;
     right: 0;
     transition: all 0.15s ease-in-out;
     opacity: 0;
-    pointer-events: none;
     position: absolute;
     background-color: ${p => p.theme.backgroundContentTint};
     padding: 8px 12px;


### PR DESCRIPTION
## What's fixed

Fixed a `pointer-events` bug in the Tooltip component that caused two issues:
- Tooltip would not appear when hovering over the trigger icon
- Tooltip would block clicks on underlying elements when visible

## Root cause

When using Stitches variants with the `css` prop, the `pointer-events: none` property was being lost from the final styles. As a result, the tooltip defaulted to `pointer-events: auto`, intercepting both hover and click events.

## Solution

Applied `pointer-events: none` using the double ampersand (`&&`) selector to increase specificity and prevent it from being overridden by variant styles.

```tsx
const Tooltip = styled.div<...>`
    && {
        pointer-events: none;
    }
    // ...
`;

```


## Demo
| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/7c15267e-2e44-4548-a68d-4cb47a753813"> | <video src="https://github.com/user-attachments/assets/817c4df5-d57f-4bbb-af33-3d7af7ab6f94"> |














