### PR TITLE
fix(uikit): adapt to nested currencies response structure

### DIFF
--- a/packages/core/src/tonkeeperApi/tonendpoint.ts
+++ b/packages/core/src/tonkeeperApi/tonendpoint.ts
@@ -240,7 +240,7 @@ export class Tonendpoint {
         return this.GET('/apps/popular');
     };
 
-    public supportedCurrencies = async (): Promise<{ code: string }[]> => {
+    public supportedCurrencies = async (): Promise<{ currencies: { code: string }[] }> => {
         const response = await fetch(`${this.tonkeeperApiUrl}/currencies?${this.toSearchParams()}`);
 
         return response.json();

--- a/packages/uikit/src/state/fiat.ts
+++ b/packages/uikit/src/state/fiat.ts
@@ -9,7 +9,7 @@ export const useAllowedFiatCurrencies = () => {
     const { tonendpoint } = useAppContext();
     return useQuery([QueryKey.allowedFiatCurrencies], async () => {
         const result = await tonendpoint.supportedCurrencies();
-        return result.map(i => i.code);
+        return result.currencies.map(i => i.code);
     });
 };
 


### PR DESCRIPTION
## What's fixed

Fixed a currency data loading issue that caused infinite loading state.

## Problem

The fiat currencies selector was stuck on infinite loader and never displayed available currencies.

## Root cause

The code expected a direct array but the API returns a nested object with a `currencies` property. Calling `.map()` on the object threw an error, breaking the data flow.

**Before (expected):**
```json
[{ "code": "USD" }, { "code": "EUR" }]
```

**After (actual):**
```json
{ "currencies": [{ "code": "USD" }, { "code": "EUR" }]}
```



## Solution
Updated both the method signature and the consumer to handle the nested currencies object:

```tsx


public supportedCurrencies = async (): Promise<{ currencies: { code: string }[] }> => {
    const response = await fetch(`${this.tonkeeperApiUrl}/currencies?${this.toSearchParams()}`);
    return response.json();
};


export const useAllowedFiatCurrencies = () => {
    const { tonendpoint } = useAppContext();
    return useQuery([QueryKey.allowedFiatCurrencies], async () => {
        const result = await tonendpoint.supportedCurrencies();
        return result.currencies.map(i => i.code);
    });
};
```



## Demo
| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/b32043d9-5b20-4161-9e72-c923b74d973b"> | <video src="https://github.com/user-attachments/assets/924c969d-ebe4-4c5b-b9f9-d0d269247555"> |