### PR TITLE
fix(uikit): remove onWheel handler to prevent jitter on trackpad scroll

### DIFF
--- a/packages/uikit/src/components/shared/carousel/index.tsx
+++ b/packages/uikit/src/components/shared/carousel/index.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren, useEffect, useMemo, WheelEvent } from 'react';
+import { FC, PropsWithChildren, useEffect, useMemo } from 'react';
 import { Carousel as ArkCarousel, useCarousel } from '@ark-ui/react';
 import styled from 'styled-components';
 import { ChevronLeftIcon, ChevronRightIcon } from '../../Icon';

--- a/packages/uikit/src/components/shared/carousel/index.tsx
+++ b/packages/uikit/src/components/shared/carousel/index.tsx
@@ -110,10 +110,6 @@ export const Carousel: FC<PropsWithChildren<CarouselProps>> = ({
                 slidesToShow={slidesToShow}
                 centerPadding={centerPadding}
                 className={className}
-                onWheel={(e: WheelEvent) => {
-                    if (e.deltaX > 0) carousel?.scrollNext();
-                    else if (e.deltaX < 0) carousel?.scrollPrev();
-                }}
             >
                 {canGoLeft && (
                     <SwipeButton position="left" onClick={() => carousel?.scrollPrev()}>


### PR DESCRIPTION
## What's fixed

Fixed carousel scroll jitter and multi-slide skipping on Mac trackpads and mouse wheel input.

## Problem

The carousel was incorrectly reacting to high-frequency wheel events, causing it to skip multiple slides per single user gesture and behave inconsistently across devices (especially macOS trackpads).

## Root cause

A custom onWheel handler was directly translating every wheel event into a discrete slide navigation action:


## Solution
Removed the onWheel handler entirely and delegated scroll behavior to the native browser scroll + carousel implementation.











## Demo
| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/78fa81c2-982f-4cfa-be17-33b4f7e6e8e9"> | <video src="https://github.com/user-attachments/assets/cc4d9c8f-3d62-49b3-8e69-2eb66117239e"> |