### PR TITLE
fix(uikit): guard against empty string conversion on currency swap

### DIFF
--- a/packages/uikit/src/components/fields/AmountDoubleInput.tsx
+++ b/packages/uikit/src/components/fields/AmountDoubleInput.tsx
@@ -277,6 +277,11 @@ export const AmountDoubleInput = forwardRef<
     };
 
     const onToggleCurrency = () => {
+        const secondaryValue =
+            currencyAmount.activeCurrencyId === currencies[0].id
+                ? currencyAmount.value2
+                : currencyAmount.value1;
+
         setCurrencyAmount(s => ({
             ...s,
             activeCurrencyId:
@@ -289,11 +294,7 @@ export const AmountDoubleInput = forwardRef<
                 currencyAmount.activeCurrencyId === currencies[0].id
                     ? currencies[1].id
                     : currencies[0].id,
-            input: inputValueToBN(
-                currencyAmount.activeCurrencyId === currencies[0].id
-                    ? currencyAmount.value2
-                    : currencyAmount.value1
-            )
+            input: secondaryValue ? inputValueToBN(secondaryValue) : new BigNumber(0)
         });
     };
 


### PR DESCRIPTION
## What's fixed

Fixed a crash when toggling currencies with an empty input value.

## Problem

When the user clicked the currency toggle button while the input field was empty (''), the application crashed with the error: `Cannot convert non-integer value to bigint`.

## Root cause

The onToggleCurrency function was calling `inputValueToBN()` directly on the secondary value without checking if it was empty. When the input was empty, `inputValueToBN('')` threw an error because it couldn't convert an empty string to a BigNumber/bigint.


## Solution
Extracted the secondary value into a variable and added a guard condition to pass new BigNumber(0) instead of trying to convert an empty string.







## Demo
| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/12acb5d2-33fe-4458-9bf8-1689340d36b5"> | <video src="https://github.com/user-attachments/assets/6cfddf4f-847b-405d-ba75-e9a9e1c4c5ca"> |