### PR TITLE
fix(uikit): prevent click event propagation on address copy

### DIFF
--- a/packages/uikit/src/components/activity/CommonAction.tsx
+++ b/packages/uikit/src/components/activity/CommonAction.tsx
@@ -72,7 +72,7 @@ export const SecondaryText = styled(Body2)`
 
 const AddressTextContent = styled(SecondaryText)`
     cursor: pointer;
-
+    width: fit-content;
     transition: opacity 0.15s ease-in-out;
     opacity: 1;
 
@@ -94,11 +94,11 @@ export const AddressText: FC<{ children: AddressTextValue }> = ({ children }) =>
     const displayChildren =
         typeof children === 'string' ? toShortValue(children, 8) : children.value;
 
-    return (
-        <AddressTextContent onClick={() => sdk.copyToClipboard(childrenValue, t('copied'))}>
-            {displayChildren}
-        </AddressTextContent>
-    );
+    const handleClick = (e: React.MouseEvent<HTMLSpanElement>) => {
+        e.stopPropagation();
+        sdk.copyToClipboard(childrenValue, t('copied'));
+    };
+    return <AddressTextContent onClick={handleClick}>{displayChildren}</AddressTextContent>;
 };
 
 const CommentMessage = styled(Body2)`


### PR DESCRIPTION
## What's fixed

Fixed an event propagation and layout issue in the AddressTextContent component that caused two problems:

Clicking on an address would both copy the address and open the transaction modal due to event bubbling

The address container had unnecessary full-width layout instead of fitting its content

## Root cause

The click handler was attached directly inline without preventing event propagation. When clicking on the address, the click event would bubble up to parent components, causing both actions to fire simultaneously. Additionally, the container lacked ```width: fit-content```, forcing it to take up the full available width.

## Solution
Extracted the click handler into a separate```handleClick``` function that calls ```e.stopPropagation()``` to prevent event bubbling. Added ```width: fit-content ``` to constrain the container to the address text width.



## Demo
| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/e9c742a6-a522-4ae7-a55c-0307105a5ad3"> | <video src="https://github.com/user-attachments/assets/27d61d7f-aafe-40c6-a9b1-ef98c0eba3e3"> |














