### PR TITLE
fix(uikit): invalidate dashboard data after wallet rename

### DIFF
--- a/packages/uikit/src/state/wallet.ts
+++ b/packages/uikit/src/state/wallet.ts
@@ -1107,6 +1107,7 @@ export const useMutateRenameAccount = <T extends Account>() => {
         await storage.updateAccountInState(account);
 
         await client.invalidateQueries([QueryKey.account]);
+        await client.invalidateQueries([QueryKey.dashboardData]);
 
         return account.clone() as T;
     });
@@ -1169,6 +1170,7 @@ export const useMutateRenameAccountDerivations = <T extends AccountMAM>() => {
         await storage.updateAccountInState(account);
 
         await client.invalidateQueries([QueryKey.account]);
+        await client.invalidateQueries([QueryKey.dashboardData]);
 
         return account.clone() as T;
     });


### PR DESCRIPTION
## What's fixed
After renaming a wallet on ```/wallet-settings```, navigating to ```/dashboard ```showed the old wallet name until a full page reload. The dashboard now reflects the new name immediately.

## Root cause
Dashboard rows cache embedded Account snapshots in```account_name``` cells from```useDashboardData```. The React Query key for dashboard data depends on wallet ids and other factors, but not on account display fields, so renaming only invalidated ```[QueryKey.account]``` and left ```dashboardData``` queries serving stale cells.

## Solution
After a successful rename in```useMutateRenameAccount``` and ```useMutateRenameAccountDerivations```, call ```invalidateQueries([QueryKey.dashboardData])``` so dashboard queries refetch and rebuild client columns (including names) from the updated accounts state.

## Demo


| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/f435b886-803e-4040-af06-0b3a735a695c"> | <video src="https://github.com/user-attachments/assets/70373b80-bf1a-4483-ad86-86dcde825df0"> |