### PR TITLE
fix(uikit): Show skeleton instead of $0 while balance is loading

### DIFF
--- a/packages/uikit/src/components/home/Balance.tsx
+++ b/packages/uikit/src/components/home/Balance.tsx
@@ -136,11 +136,15 @@ export const Balance: FC<{
         };
     }, [total]);
 
+    if (total === undefined) {
+        return <BalanceSkeleton />;
+    }
+
     return (
         <Block>
             <MessageBlock error={error} isFetching={isFetching} />
             <Amount>
-                <span>{formatFiatCurrency(fiat, total || 0)}</span>
+                <span>{formatFiatCurrency(fiat, total)}</span>
                 <NetworkBadge network={network} />
                 {!!batteryBalance && canSeeBattery && (
                     <BatteryBalanceIconStyled


### PR DESCRIPTION
quick UI fix for the visible problem
the better fix would require reviewing Home screen states depending on the data readiness