### PR TITLE
fix(core): allow multisig wallets through TonConnect sendTransaction

### DIFF
--- a/packages/core/src/service/tonConnect/__tests__/ton-connect-sse.test.ts
+++ b/packages/core/src/service/tonConnect/__tests__/ton-connect-sse.test.ts
@@ -144,6 +144,23 @@ const makeSignDataRequest = (
     }
 });
 
+const makeDisconnectRequest = (): TonConnectAppRequest<'http'> =>
+    ({
+        connection: makeConnection(),
+        request: {
+            id: 'req-disc',
+            method: 'disconnect',
+            params: [] as never
+        }
+    } as TonConnectAppRequest<'http'>);
+
+// A multisig wallet is a smart-contract wallet: it has id + rawAddress but no
+// publicKey/version, so `isStandardTonWallet` returns false for it.
+const makeMultisigWallet = () => ({
+    id: walletId,
+    rawAddress: '0:multisig'
+});
+
 const fakeStorage = {} as IStorage;
 
 const setupSse = async ({
@@ -283,6 +300,28 @@ describe('TonConnectSSE.handleMessage', () => {
             );
         });
 
+        // Regression: PR #596 introduced `validatePayload` and reused a helper
+        // intended for the disconnect path that filters out non-standard
+        // wallets via `isStandardTonWallet`. Multisig wallets are
+        // smart-contract wallets without a publicKey/version, so they used to
+        // always be rejected here with `Unknown session`. This test makes sure
+        // multisig requests are forwarded like any other connection.
+        it('forwards requests from multisig wallets (regression for #625)', async () => {
+            mocks.getWalletById.mockReturnValue(makeMultisigWallet());
+            mocks.isStandardTonWallet.mockReturnValue(false);
+
+            const { handleMessage, onRequest } = await setupSse();
+            const payload = { messages: [{ address: '0:dead', amount: '1' }] };
+
+            await handleMessage(makeSendTransactionRequest(payload));
+
+            expect(mocks.replyHttpBadRequestResponse).not.toHaveBeenCalled();
+            expect(onRequest).toHaveBeenCalledTimes(1);
+            expect(onRequest).toHaveBeenCalledWith(
+                expect.objectContaining({ kind: 'sendTransaction', payload })
+            );
+        });
+
     });
 
     describe('signData', () => {
@@ -341,6 +380,61 @@ describe('TonConnectSSE.handleMessage', () => {
             expect(mocks.replyHttpBadRequestResponse).toHaveBeenCalledWith(
                 expect.objectContaining({ message: 'Unknown session' })
             );
+        });
+
+        it('forwards signData from multisig wallets (regression for #625)', async () => {
+            mocks.getWalletById.mockReturnValue(makeMultisigWallet());
+            mocks.isStandardTonWallet.mockReturnValue(false);
+
+            const { handleMessage, onRequest } = await setupSse();
+
+            await handleMessage(makeSignDataRequest());
+
+            expect(mocks.replyHttpBadRequestResponse).not.toHaveBeenCalled();
+            expect(onRequest).toHaveBeenCalledTimes(1);
+            expect(onRequest).toHaveBeenCalledWith(
+                expect.objectContaining({ kind: 'signData' })
+            );
+        });
+    });
+
+    describe('disconnect', () => {
+        it('clears storage and notifies listeners for standard wallets', async () => {
+            const { handleMessage, onDisconnect } = await setupSse();
+
+            await handleMessage(makeDisconnectRequest());
+
+            expect(mocks.disconnectHttpAccountConnection).toHaveBeenCalledTimes(1);
+            expect(mocks.replyHttpDisconnectResponse).toHaveBeenCalledTimes(1);
+            expect(onDisconnect).toHaveBeenCalledTimes(1);
+        });
+
+        // Before this fix, multisig disconnects via the bridge were silently
+        // dropped because the helper filtered out non-standard wallets, so
+        // the dApp could not detach itself from a multisig account.
+        it('processes disconnects from multisig wallets (regression for #625)', async () => {
+            mocks.getWalletById.mockReturnValue(makeMultisigWallet());
+            mocks.isStandardTonWallet.mockReturnValue(false);
+
+            const { handleMessage, onDisconnect } = await setupSse();
+
+            await handleMessage(makeDisconnectRequest());
+
+            expect(mocks.disconnectHttpAccountConnection).toHaveBeenCalledTimes(1);
+            expect(mocks.replyHttpDisconnectResponse).toHaveBeenCalledTimes(1);
+            expect(onDisconnect).toHaveBeenCalledTimes(1);
+        });
+
+        it('returns silently when the client session id is unknown', async () => {
+            mocks.getWalletById.mockReturnValue(undefined);
+
+            const { handleMessage, onDisconnect } = await setupSse();
+
+            await handleMessage(makeDisconnectRequest());
+
+            expect(mocks.disconnectHttpAccountConnection).not.toHaveBeenCalled();
+            expect(mocks.replyHttpDisconnectResponse).not.toHaveBeenCalled();
+            expect(onDisconnect).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/core/src/service/tonConnect/connectionService.ts
+++ b/packages/core/src/service/tonConnect/connectionService.ts
@@ -228,7 +228,7 @@ const disconnectInjectedDappFromAllWallets = async (storage: IStorage, webViewOr
  */
 export const disconnectHttpAccountConnection = async (options: {
     storage: IStorage;
-    wallet: Pick<TonWalletStandard, 'id' | 'publicKey'>;
+    wallet: Pick<TonWalletStandard, 'id'> & Partial<Pick<TonWalletStandard, 'publicKey'>>;
     clientSessionId: string;
 }) => {
     let connections = await getTonWalletConnections(options.storage, options.wallet);

--- a/packages/core/src/service/tonConnect/ton-connect-sse.ts
+++ b/packages/core/src/service/tonConnect/ton-connect-sse.ts
@@ -3,7 +3,7 @@ import {
     disconnectHttpAccountConnection,
     getTonWalletConnections
 } from './connectionService';
-import { isStandardTonWallet, WalletId } from '../../entries/wallet';
+import { WalletId } from '../../entries/wallet';
 import { getLastEventId, subscribeTonConnect } from './httpBridge';
 import { accountsStorage } from '../accountsStorage';
 import { IStorage } from '../../Storage';
@@ -144,19 +144,13 @@ export class TonConnectSSE {
         await this.reconnect();
     };
 
-    private getStandardWalletByClientSessionId = async (clientSessionId: string) => {
+    private getWalletByClientSessionId = async (clientSessionId: string) => {
         const accounts = await accountsStorage(this.storage).getAccounts();
-        const wallet = getWalletById(accounts, this.dist[clientSessionId]);
-
-        if (!wallet || !isStandardTonWallet(wallet)) {
-            return null;
-        }
-
-        return wallet;
+        return getWalletById(accounts, this.dist[clientSessionId]) ?? null;
     };
 
     private onDisconnect = async ({ connection, request }: TonConnectAppRequest<'http'>) => {
-        const wallet = await this.getStandardWalletByClientSessionId(connection.clientSessionId);
+        const wallet = await this.getWalletByClientSessionId(connection.clientSessionId);
         if (!wallet) {
             return;
         }
@@ -202,7 +196,7 @@ export class TonConnectSSE {
         const validatePayload = async (
             payload: TonConnectAppRequestPayload['payload']
         ): Promise<boolean> => {
-            const wallet = await this.getStandardWalletByClientSessionId(
+            const wallet = await this.getWalletByClientSessionId(
                 params.connection.clientSessionId
             );
             if (!wallet) {


### PR DESCRIPTION
Fixes #625.

## Root cause

PR #596 added a `validatePayload` gate in `TonConnectSSE.handleMessage` and reused `getStandardWalletByClientSessionId`, a helper originally written for the disconnect path. That helper filters via `isStandardTonWallet` (requires both `publicKey` and `version`). Multisig wallets are smart-contract `TonContract`s with neither, so every `sendTransaction` and `signData` from a multisig connection now resolves to `null` and is rejected with `Unknown session`, even though the connection is in storage and listed under Connected Apps.

Pre-#596 there was no wallet-type filter on this path, and multisig sendTransactions worked. After #596 they always fail.

## Fix

- Rename the helper to `getWalletByClientSessionId` and drop the standard filter. Downstream (`checkTonConnectFromAndNetwork`, renderer's multisig sender path) already handles multisig correctly.
- Use the loosened lookup in both `validatePayload` (sendTransaction / signData) and `onDisconnect`. The disconnect path's filter was silently dropping multisig disconnects too.
- Widen `disconnectHttpAccountConnection`'s `wallet` parameter to make `publicKey` optional, matching what `getTonWalletConnections` and `setAccountConnection` already accept.

## Tests

Added to `ton-connect-sse.test.ts`:

- multisig `sendTransaction` is forwarded to `listeners.onRequest`
- multisig `signData` is forwarded
- standard-wallet disconnect still clears storage and notifies listeners
- multisig disconnect now clears storage and notifies listeners
- disconnect with an unknown `clientSessionId` still no-ops silently

Existing tests for standard wallets and the legitimate `Unknown session` (unknown `clientSessionId`) case are unchanged and still pass.

## Verified

Built a Desktop bundle off this branch (bundle id `com.tonapps.tonkeeperpro`, shares Application Support with the production install), connected `app.kton.io` with a multisig wallet, and confirmed `sendTransaction` now reaches the multisig signing flow instead of being rejected with `Unknown session`.