### PR TITLE
feat(desktop): add update-available banner for Linux

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -114,7 +114,7 @@ const config: ForgeConfig = {
             },
             ['linux']
         ),
-        ...(process.argv[3] === 'x64'
+        ...(['x64', 'arm64'].includes(process.argv[3])
             ? [
                   new MakerAppImage(
                       {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,6 +19,8 @@
         "publish:arm": "electron-forge publish --arch=arm64",
         "publish:intel": "electron-forge publish --arch=x64",
         "publish:universal": "electron-forge publish --arch=universal",
+        "lint": "eslint --ext .ts,.tsx .",
+        "test": "vitest run",
         "build": "yarn make",
         "build:desktop": "yarn make",
         "typecheck": "tsc --noEmit",
@@ -60,6 +62,7 @@
         "ts-loader": "^9.2.2",
         "ts-node": "^10.0.0",
         "typescript": "^4.9.4",
+        "vitest": "^3.2.4",
         "webpack": "^5.104.0"
     },
     "dependencies": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,7 +19,6 @@
         "publish:arm": "electron-forge publish --arch=arm64",
         "publish:intel": "electron-forge publish --arch=x64",
         "publish:universal": "electron-forge publish --arch=universal",
-        "lint": "eslint --ext .ts,.tsx .",
         "test": "vitest run",
         "build": "yarn make",
         "build:desktop": "yarn make",

--- a/apps/desktop/src/app/App.tsx
+++ b/apps/desktop/src/app/App.tsx
@@ -77,6 +77,7 @@ import { DesktopAppSdk } from '../libs/appSdk';
 import { useAnalytics, useAppHeight, useAppWidth } from '../libs/hooks';
 import { DeepLinkSubscription } from './components/DeepLink';
 import { TonConnectSubscription } from './components/TonConnectSubscription';
+import { UpdateBanner } from './components/UpdateBanner';
 import { useGlobalPreferencesQuery } from '@tonkeeper/uikit/dist/state/global-preferences';
 import { DesktopManageMultisigsPage } from '@tonkeeper/uikit/dist/desktop-pages/manage-multisig-wallets/DesktopManageMultisigs';
 import { useGlobalSetup } from '@tonkeeper/uikit/dist/state/globalSetup';
@@ -341,6 +342,7 @@ export const Loader: FC = () => {
                 <CopyNotification hideSimpleCopyNotifications />
                 <QrScanner />
                 <ModalsRoot />
+                <UpdateBanner />
             </CryptoStrategyInstaller>
         </AppContext.Provider>
     );

--- a/apps/desktop/src/app/components/UpdateBanner.tsx
+++ b/apps/desktop/src/app/components/UpdateBanner.tsx
@@ -1,0 +1,73 @@
+import { FC, useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { Body3, Label2 } from '@tonkeeper/uikit/dist/components/Text';
+import { Button } from '@tonkeeper/uikit/dist/components/fields/Button';
+import { useAppSdk } from '@tonkeeper/uikit/dist/hooks/appSdk';
+
+const DISMISS_KEY = 'update-banner-dismissed-version';
+
+const Banner = styled.div`
+    position: fixed;
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+
+    display: flex;
+    align-items: center;
+    gap: 16px;
+
+    background: ${p => p.theme.backgroundContent};
+    border: 1px solid ${p => p.theme.separatorCommon};
+    border-radius: ${p => p.theme.cornerSmall};
+    padding: 12px 16px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+`;
+
+const TextColumn = styled.div`
+    display: flex;
+    flex-direction: column;
+
+    ${Body3} {
+        color: ${p => p.theme.textSecondary};
+    }
+`;
+
+const Actions = styled.div`
+    display: flex;
+    gap: 8px;
+`;
+
+export const UpdateBanner: FC = () => {
+    const sdk = useAppSdk();
+    const [info, setInfo] = useState<{ version: string; url: string } | undefined>();
+
+    useEffect(() => {
+        window.backgroundApi.onUpdateAvailable(value => setInfo(value));
+    }, []);
+
+    if (!info) return null;
+    if (localStorage.getItem(DISMISS_KEY) === info.version) return null;
+
+    return (
+        <Banner>
+            <TextColumn>
+                <Label2>New version available</Label2>
+                <Body3>Tonkeeper {info.version} is ready to download.</Body3>
+            </TextColumn>
+            <Actions>
+                <Button
+                    onClick={() => {
+                        localStorage.setItem(DISMISS_KEY, info.version);
+                        setInfo(undefined);
+                    }}
+                >
+                    Later
+                </Button>
+                <Button primary onClick={() => sdk.openPage(info.url)}>
+                    Download
+                </Button>
+            </Actions>
+        </Banner>
+    );
+};

--- a/apps/desktop/src/app/components/UpdateBanner.tsx
+++ b/apps/desktop/src/app/components/UpdateBanner.tsx
@@ -43,7 +43,7 @@ export const UpdateBanner: FC = () => {
     const [info, setInfo] = useState<{ version: string; url: string } | undefined>();
 
     useEffect(() => {
-        window.backgroundApi.onUpdateAvailable(value => setInfo(value));
+        return window.backgroundApi.onUpdateAvailable(value => setInfo(value));
     }, []);
 
     if (!info) return null;

--- a/apps/desktop/src/app/components/UpdateBanner.tsx
+++ b/apps/desktop/src/app/components/UpdateBanner.tsx
@@ -12,16 +12,14 @@ const Banner = styled.div`
     left: 50%;
     transform: translateX(-50%);
     z-index: 1000;
-
     display: flex;
     align-items: center;
     gap: 16px;
-
     background: ${p => p.theme.backgroundContent};
     border: 1px solid ${p => p.theme.separatorCommon};
     border-radius: ${p => p.theme.cornerSmall};
     padding: 12px 16px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+    box-shadow: 0 8px 24px rgb(0 0 0 / 18%);
 `;
 
 const TextColumn = styled.div`

--- a/apps/desktop/src/backgroud.d.ts
+++ b/apps/desktop/src/backgroud.d.ts
@@ -1,3 +1,8 @@
+interface UpdateInfo {
+    version: string;
+    url: string;
+}
+
 interface BackgroundApi {
     platform: () => string;
     arch: () => string;
@@ -9,6 +14,7 @@ interface BackgroundApi {
     onTonConnectRequest: (callback: (value: TonConnectAppRequestPayload) => void) => void;
     onTonConnectDisconnect: (callback: (value: AccountConnection) => void) => void;
     onRefresh: (callback: () => void) => void;
+    onUpdateAvailable: (callback: (value: UpdateInfo) => void) => void;
 }
 
 declare global {

--- a/apps/desktop/src/backgroud.d.ts
+++ b/apps/desktop/src/backgroud.d.ts
@@ -14,7 +14,7 @@ interface BackgroundApi {
     onTonConnectRequest: (callback: (value: TonConnectAppRequestPayload) => void) => void;
     onTonConnectDisconnect: (callback: (value: AccountConnection) => void) => void;
     onRefresh: (callback: () => void) => void;
-    onUpdateAvailable: (callback: (value: UpdateInfo) => void) => void;
+    onUpdateAvailable: (callback: (value: UpdateInfo) => void) => () => void;
 }
 
 declare global {

--- a/apps/desktop/src/electron/__tests__/updateCheck.test.ts
+++ b/apps/desktop/src/electron/__tests__/updateCheck.test.ts
@@ -74,25 +74,19 @@ describe('evaluateRelease', () => {
     });
 
     it('strips the leading v from the tag', () => {
-        const result = evaluateRelease(
-            { ...baseRelease, tag_name: 'v10.0.0' },
-            '9.0.0',
-            undefined
-        );
+        const result = evaluateRelease({ ...baseRelease, tag_name: 'v10.0.0' }, '9.0.0', undefined);
         expect(result?.version).toBe('10.0.0');
     });
 
     it('accepts tag names without a v prefix', () => {
-        const result = evaluateRelease(
-            { ...baseRelease, tag_name: '4.7.0' },
-            '4.6.1',
-            undefined
-        );
+        const result = evaluateRelease({ ...baseRelease, tag_name: '4.7.0' }, '4.6.1', undefined);
         expect(result?.version).toBe('4.7.0');
     });
 
     it('returns undefined for draft releases', () => {
-        expect(evaluateRelease({ ...baseRelease, draft: true }, '4.6.1', undefined)).toBeUndefined();
+        expect(
+            evaluateRelease({ ...baseRelease, draft: true }, '4.6.1', undefined)
+        ).toBeUndefined();
     });
 
     it('returns undefined for pre-releases', () => {
@@ -129,11 +123,7 @@ describe('evaluateRelease', () => {
     });
 
     it('falls back to the releases-latest URL when html_url is missing', () => {
-        const result = evaluateRelease(
-            { ...baseRelease, html_url: undefined },
-            '4.6.1',
-            undefined
-        );
+        const result = evaluateRelease({ ...baseRelease, html_url: undefined }, '4.6.1', undefined);
         expect(result?.url).toBe('https://github.com/tonkeeper/tonkeeper-web/releases/latest');
     });
 });

--- a/apps/desktop/src/electron/__tests__/updateCheck.test.ts
+++ b/apps/desktop/src/electron/__tests__/updateCheck.test.ts
@@ -1,0 +1,321 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+    app: { getVersion: vi.fn(() => '4.6.1') },
+    BrowserWindow: { getAllWindows: vi.fn(() => []) }
+}));
+vi.mock('electron-log/main', () => ({
+    default: { warn: vi.fn(), info: vi.fn() }
+}));
+
+import { app, BrowserWindow } from 'electron';
+import log from 'electron-log/main';
+import {
+    _resetForTesting,
+    checkOnce,
+    evaluateRelease,
+    isNewer,
+    startUpdateCheck
+} from '../updateCheck';
+
+describe('isNewer', () => {
+    it('returns true when the latest version is strictly greater', () => {
+        expect(isNewer('4.7.0', '4.6.1')).toBe(true);
+        expect(isNewer('5.0.0', '4.99.99')).toBe(true);
+        expect(isNewer('4.6.2', '4.6.1')).toBe(true);
+    });
+
+    it('returns false when versions are equal', () => {
+        expect(isNewer('4.6.1', '4.6.1')).toBe(false);
+    });
+
+    it('returns false when the latest is older', () => {
+        expect(isNewer('4.5.9', '4.6.0')).toBe(false);
+        expect(isNewer('3.99.99', '4.0.0')).toBe(false);
+    });
+
+    it('compares minor and patch correctly when major is equal', () => {
+        expect(isNewer('4.6.1', '4.5.99')).toBe(true);
+        expect(isNewer('4.5.99', '4.6.0')).toBe(false);
+    });
+
+    it('strips pre-release suffixes before comparing', () => {
+        // Pre-release suffix on the right of the dash is ignored, so these
+        // compare as equal numerics and are not "newer".
+        expect(isNewer('4.7.0-beta.1', '4.7.0')).toBe(false);
+        expect(isNewer('4.7.0', '4.7.0-beta.1')).toBe(false);
+    });
+
+    it('treats missing components as zero', () => {
+        expect(isNewer('4.7', '4.6.1')).toBe(true);
+        expect(isNewer('4', '3.99.99')).toBe(true);
+        expect(isNewer('4.6.1.1', '4.6.1')).toBe(true);
+    });
+
+    it('tolerates non-numeric junk by parsing as 0', () => {
+        expect(isNewer('abc', '4.6.1')).toBe(false);
+        expect(isNewer('4.6.1', 'abc')).toBe(true);
+    });
+});
+
+describe('evaluateRelease', () => {
+    const baseRelease = {
+        tag_name: 'v4.7.0',
+        html_url: 'https://github.com/tonkeeper/tonkeeper-web/releases/tag/v4.7.0',
+        draft: false,
+        prerelease: false
+    };
+
+    it('returns UpdateInfo for a newer stable release', () => {
+        expect(evaluateRelease(baseRelease, '4.6.1', undefined)).toEqual({
+            version: '4.7.0',
+            url: baseRelease.html_url
+        });
+    });
+
+    it('strips the leading v from the tag', () => {
+        const result = evaluateRelease(
+            { ...baseRelease, tag_name: 'v10.0.0' },
+            '9.0.0',
+            undefined
+        );
+        expect(result?.version).toBe('10.0.0');
+    });
+
+    it('accepts tag names without a v prefix', () => {
+        const result = evaluateRelease(
+            { ...baseRelease, tag_name: '4.7.0' },
+            '4.6.1',
+            undefined
+        );
+        expect(result?.version).toBe('4.7.0');
+    });
+
+    it('returns undefined for draft releases', () => {
+        expect(evaluateRelease({ ...baseRelease, draft: true }, '4.6.1', undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for pre-releases', () => {
+        expect(
+            evaluateRelease({ ...baseRelease, prerelease: true }, '4.6.1', undefined)
+        ).toBeUndefined();
+    });
+
+    it('returns undefined when no tag_name is present', () => {
+        expect(
+            evaluateRelease({ ...baseRelease, tag_name: undefined }, '4.6.1', undefined)
+        ).toBeUndefined();
+    });
+
+    it('returns undefined when the response is null or undefined', () => {
+        expect(evaluateRelease(null, '4.6.1', undefined)).toBeUndefined();
+        expect(evaluateRelease(undefined, '4.6.1', undefined)).toBeUndefined();
+    });
+
+    it('returns undefined when the release is older than the current version', () => {
+        expect(evaluateRelease(baseRelease, '4.7.0', undefined)).toBeUndefined();
+        expect(evaluateRelease(baseRelease, '4.8.0', undefined)).toBeUndefined();
+    });
+
+    it('returns undefined when the version was previously notified', () => {
+        expect(evaluateRelease(baseRelease, '4.6.1', '4.7.0')).toBeUndefined();
+    });
+
+    it('still returns UpdateInfo when a different older version was notified', () => {
+        expect(evaluateRelease(baseRelease, '4.6.1', '4.6.5')).toEqual({
+            version: '4.7.0',
+            url: baseRelease.html_url
+        });
+    });
+
+    it('falls back to the releases-latest URL when html_url is missing', () => {
+        const result = evaluateRelease(
+            { ...baseRelease, html_url: undefined },
+            '4.6.1',
+            undefined
+        );
+        expect(result?.url).toBe('https://github.com/tonkeeper/tonkeeper-web/releases/latest');
+    });
+});
+
+describe('checkOnce', () => {
+    const mockedFetch = vi.fn();
+
+    beforeEach(() => {
+        _resetForTesting();
+        vi.stubGlobal('fetch', mockedFetch);
+        vi.mocked(app.getVersion).mockReturnValue('4.6.1');
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([]);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    function mockJsonResponse(body: unknown, ok = true, status = 200) {
+        mockedFetch.mockResolvedValueOnce({
+            ok,
+            status,
+            json: async () => body
+        } as Response);
+    }
+
+    function makeWindow() {
+        return { webContents: { send: vi.fn() } };
+    }
+
+    it('broadcasts update-available to every open window when a newer release exists', async () => {
+        const win1 = makeWindow();
+        const win2 = makeWindow();
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([win1, win2] as never);
+        mockJsonResponse({
+            tag_name: 'v4.7.0',
+            html_url: 'https://example.com/v4.7.0',
+            draft: false,
+            prerelease: false
+        });
+
+        await checkOnce();
+
+        const expectedPayload = { version: '4.7.0', url: 'https://example.com/v4.7.0' };
+        expect(win1.webContents.send).toHaveBeenCalledWith('update-available', expectedPayload);
+        expect(win2.webContents.send).toHaveBeenCalledWith('update-available', expectedPayload);
+        expect(log.info).toHaveBeenCalledWith('update available: 4.7.0');
+    });
+
+    it('does not broadcast the same version twice in a row', async () => {
+        const win = makeWindow();
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([win] as never);
+        mockJsonResponse({
+            tag_name: 'v4.7.0',
+            html_url: 'https://example.com/v4.7.0',
+            draft: false,
+            prerelease: false
+        });
+        mockJsonResponse({
+            tag_name: 'v4.7.0',
+            html_url: 'https://example.com/v4.7.0',
+            draft: false,
+            prerelease: false
+        });
+
+        await checkOnce();
+        await checkOnce();
+
+        expect(win.webContents.send).toHaveBeenCalledTimes(1);
+    });
+
+    it('broadcasts again when a later version appears after one was already notified', async () => {
+        const win = makeWindow();
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([win] as never);
+        mockJsonResponse({
+            tag_name: 'v4.7.0',
+            html_url: 'https://example.com/v4.7.0',
+            draft: false,
+            prerelease: false
+        });
+        mockJsonResponse({
+            tag_name: 'v4.8.0',
+            html_url: 'https://example.com/v4.8.0',
+            draft: false,
+            prerelease: false
+        });
+
+        await checkOnce();
+        await checkOnce();
+
+        expect(win.webContents.send).toHaveBeenCalledTimes(2);
+        expect(win.webContents.send).toHaveBeenLastCalledWith('update-available', {
+            version: '4.8.0',
+            url: 'https://example.com/v4.8.0'
+        });
+    });
+
+    it('does not broadcast drafts or pre-releases', async () => {
+        const win = makeWindow();
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([win] as never);
+        mockJsonResponse({ tag_name: 'v4.7.0', draft: true });
+        mockJsonResponse({ tag_name: 'v4.7.0', prerelease: true });
+
+        await checkOnce();
+        await checkOnce();
+
+        expect(win.webContents.send).not.toHaveBeenCalled();
+    });
+
+    it('logs and returns quietly on non-2xx HTTP responses', async () => {
+        mockJsonResponse({}, false, 502);
+
+        await expect(checkOnce()).resolves.toBeUndefined();
+        expect(log.warn).toHaveBeenCalledWith('update check: HTTP 502');
+    });
+
+    it('logs and returns quietly on network errors without throwing', async () => {
+        mockedFetch.mockRejectedValueOnce(new Error('ECONNRESET'));
+
+        await expect(checkOnce()).resolves.toBeUndefined();
+        expect(log.warn).toHaveBeenCalledWith('update check failed', expect.any(Error));
+    });
+
+    it('uses the GitHub Releases /latest endpoint with a Tonkeeper user-agent', async () => {
+        mockJsonResponse({ tag_name: 'v4.6.1', draft: false, prerelease: false });
+
+        await checkOnce();
+
+        expect(mockedFetch).toHaveBeenCalledWith(
+            'https://api.github.com/repos/tonkeeper/tonkeeper-web/releases/latest',
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    'User-Agent': 'Tonkeeper/4.6.1',
+                    Accept: 'application/vnd.github+json'
+                })
+            })
+        );
+    });
+});
+
+describe('startUpdateCheck', () => {
+    const origPlatform = process.platform;
+
+    function setPlatform(value: NodeJS.Platform) {
+        Object.defineProperty(process, 'platform', { value, configurable: true });
+    }
+
+    beforeEach(() => {
+        _resetForTesting();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        setPlatform(origPlatform);
+    });
+
+    it('schedules timers on Linux', () => {
+        setPlatform('linux');
+        startUpdateCheck();
+        expect(vi.getTimerCount()).toBeGreaterThan(0);
+    });
+
+    it('does not schedule timers on macOS', () => {
+        setPlatform('darwin');
+        startUpdateCheck();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('does not schedule timers on Windows', () => {
+        setPlatform('win32');
+        startUpdateCheck();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('is idempotent — repeated calls on Linux do not duplicate timers', () => {
+        setPlatform('linux');
+        startUpdateCheck();
+        const after1 = vi.getTimerCount();
+        startUpdateCheck();
+        startUpdateCheck();
+        expect(vi.getTimerCount()).toBe(after1);
+    });
+});

--- a/apps/desktop/src/electron/updateCheck.ts
+++ b/apps/desktop/src/electron/updateCheck.ts
@@ -1,0 +1,76 @@
+import { app, BrowserWindow } from 'electron';
+import log from 'electron-log/main';
+
+const RELEASES_URL =
+    'https://api.github.com/repos/tonkeeper/tonkeeper-web/releases/latest';
+const INITIAL_DELAY_MS = 15_000;
+const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+export interface UpdateInfo {
+    version: string;
+    url: string;
+}
+
+let lastNotified: string | undefined;
+let timer: NodeJS.Timeout | undefined;
+
+function isNewer(latest: string, current: string): boolean {
+    const parse = (v: string) =>
+        v.split('-')[0]
+            .split('.')
+            .map(n => parseInt(n, 10) || 0);
+    const a = parse(latest);
+    const b = parse(current);
+    for (let i = 0; i < Math.max(a.length, b.length); i++) {
+        const x = a[i] ?? 0;
+        const y = b[i] ?? 0;
+        if (x !== y) return x > y;
+    }
+    return false;
+}
+
+async function checkOnce() {
+    try {
+        const res = await fetch(RELEASES_URL, {
+            headers: {
+                'User-Agent': `Tonkeeper/${app.getVersion()}`,
+                Accept: 'application/vnd.github+json'
+            }
+        });
+        if (!res.ok) {
+            log.warn(`update check: HTTP ${res.status}`);
+            return;
+        }
+        const release = (await res.json()) as {
+            tag_name?: string;
+            html_url?: string;
+            prerelease?: boolean;
+            draft?: boolean;
+        };
+        if (!release.tag_name || release.draft || release.prerelease) return;
+
+        const latest = release.tag_name.replace(/^v/, '');
+        if (!isNewer(latest, app.getVersion())) return;
+        if (lastNotified === latest) return;
+
+        lastNotified = latest;
+        const payload: UpdateInfo = {
+            version: latest,
+            url: release.html_url ?? 'https://github.com/tonkeeper/tonkeeper-web/releases/latest'
+        };
+        for (const win of BrowserWindow.getAllWindows()) {
+            win.webContents.send('update-available', payload);
+        }
+        log.info(`update available: ${latest}`);
+    } catch (e) {
+        log.warn('update check failed', e);
+    }
+}
+
+export function startUpdateCheck() {
+    if (timer) return;
+    // macOS has working Squirrel.Mac auto-updates via update-electron-app.
+    if (process.platform === 'darwin') return;
+    setTimeout(checkOnce, INITIAL_DELAY_MS);
+    timer = setInterval(checkOnce, CHECK_INTERVAL_MS);
+}

--- a/apps/desktop/src/electron/updateCheck.ts
+++ b/apps/desktop/src/electron/updateCheck.ts
@@ -1,8 +1,7 @@
 import { app, BrowserWindow } from 'electron';
 import log from 'electron-log/main';
 
-const RELEASES_URL =
-    'https://api.github.com/repos/tonkeeper/tonkeeper-web/releases/latest';
+const RELEASES_URL = 'https://api.github.com/repos/tonkeeper/tonkeeper-web/releases/latest';
 const INITIAL_DELAY_MS = 15_000;
 const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
@@ -22,10 +21,11 @@ let lastNotified: string | undefined;
 let timer: NodeJS.Timeout | undefined;
 
 export function isNewer(latest: string, current: string): boolean {
-    const parse = (v: string) =>
-        v.split('-')[0]
+    const parse = (v: string): number[] =>
+        v
+            .split('-')[0]
             .split('.')
-            .map(n => parseInt(n, 10) || 0);
+            .map(n => parseInt(n) || 0);
     const a = parse(latest);
     const b = parse(current);
     for (let i = 0; i < Math.max(a.length, b.length); i++) {

--- a/apps/desktop/src/electron/updateCheck.ts
+++ b/apps/desktop/src/electron/updateCheck.ts
@@ -11,10 +11,17 @@ export interface UpdateInfo {
     url: string;
 }
 
+export interface ReleaseResponse {
+    tag_name?: string;
+    html_url?: string;
+    prerelease?: boolean;
+    draft?: boolean;
+}
+
 let lastNotified: string | undefined;
 let timer: NodeJS.Timeout | undefined;
 
-function isNewer(latest: string, current: string): boolean {
+export function isNewer(latest: string, current: string): boolean {
     const parse = (v: string) =>
         v.split('-')[0]
             .split('.')
@@ -29,7 +36,22 @@ function isNewer(latest: string, current: string): boolean {
     return false;
 }
 
-async function checkOnce() {
+export function evaluateRelease(
+    release: ReleaseResponse | null | undefined,
+    currentVersion: string,
+    previouslyNotified: string | undefined
+): UpdateInfo | undefined {
+    if (!release || !release.tag_name || release.draft || release.prerelease) return undefined;
+    const latest = release.tag_name.replace(/^v/, '');
+    if (!isNewer(latest, currentVersion)) return undefined;
+    if (previouslyNotified === latest) return undefined;
+    return {
+        version: latest,
+        url: release.html_url ?? 'https://github.com/tonkeeper/tonkeeper-web/releases/latest'
+    };
+}
+
+export async function checkOnce() {
     try {
         const res = await fetch(RELEASES_URL, {
             headers: {
@@ -41,27 +63,15 @@ async function checkOnce() {
             log.warn(`update check: HTTP ${res.status}`);
             return;
         }
-        const release = (await res.json()) as {
-            tag_name?: string;
-            html_url?: string;
-            prerelease?: boolean;
-            draft?: boolean;
-        };
-        if (!release.tag_name || release.draft || release.prerelease) return;
+        const release = (await res.json()) as ReleaseResponse;
+        const update = evaluateRelease(release, app.getVersion(), lastNotified);
+        if (!update) return;
 
-        const latest = release.tag_name.replace(/^v/, '');
-        if (!isNewer(latest, app.getVersion())) return;
-        if (lastNotified === latest) return;
-
-        lastNotified = latest;
-        const payload: UpdateInfo = {
-            version: latest,
-            url: release.html_url ?? 'https://github.com/tonkeeper/tonkeeper-web/releases/latest'
-        };
+        lastNotified = update.version;
         for (const win of BrowserWindow.getAllWindows()) {
-            win.webContents.send('update-available', payload);
+            win.webContents.send('update-available', update);
         }
-        log.info(`update available: ${latest}`);
+        log.info(`update available: ${update.version}`);
     } catch (e) {
         log.warn('update check failed', e);
     }
@@ -69,8 +79,18 @@ async function checkOnce() {
 
 export function startUpdateCheck() {
     if (timer) return;
-    // macOS has working Squirrel.Mac auto-updates via update-electron-app.
-    if (process.platform === 'darwin') return;
+    // Auto-update notifications elsewhere: macOS via Squirrel.Mac (update-electron-app),
+    // Windows via Squirrel.Windows. Linux has no built-in updater, so the banner is its
+    // only update signal.
+    if (process.platform !== 'linux') return;
     setTimeout(checkOnce, INITIAL_DELAY_MS);
     timer = setInterval(checkOnce, CHECK_INTERVAL_MS);
+}
+
+export function _resetForTesting() {
+    lastNotified = undefined;
+    if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+    }
 }

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -3,6 +3,7 @@ import { BrowserWindow, app, powerMonitor } from 'electron';
 import log from 'electron-log/main';
 import { updateElectronApp } from 'update-electron-app';
 import { MainWindow } from './electron/mainWindow';
+import { startUpdateCheck } from './electron/updateCheck';
 import {
     setDefaultProtocolClient,
     setProtocolHandlerOSX,
@@ -92,4 +93,8 @@ app.on('activate', () => {
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and import them here.
 
-updateElectronApp({ logger: log });
+if (process.platform !== 'linux') {
+    updateElectronApp({ logger: log });
+}
+
+startUpdateCheck();

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -22,9 +22,7 @@ ipcRenderer.on('disconnect', (_event, value: AccountConnection) =>
     tonConnectDisconnects$.next(value)
 );
 ipcRenderer.on('refresh', () => refreshes$.next());
-ipcRenderer.on('update-available', (_event, value: UpdateInfo) =>
-    updateAvailable$.next(value)
-);
+ipcRenderer.on('update-available', (_event, value: UpdateInfo) => updateAvailable$.next(value));
 
 contextBridge.exposeInMainWorld('backgroundApi', {
     platform: () => process.platform,

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -6,11 +6,13 @@ import { Message } from './libs/message';
 import { AccountConnection } from '@tonkeeper/core/dist/service/tonConnect/connectionService';
 import { TonConnectAppRequestPayload } from '@tonkeeper/core/dist/entries/tonConnect';
 import { atom, replaySubject } from '@tonkeeper/core/dist/entries/atom';
+import type { UpdateInfo } from './electron/updateCheck';
 
 const tcRequests$ = atom<string>(undefined);
 const tonConnectRequests$ = replaySubject<TonConnectAppRequestPayload>('all');
 const tonConnectDisconnects$ = replaySubject<AccountConnection>('all');
 const refreshes$ = replaySubject<void>('all');
+const updateAvailable$ = atom<UpdateInfo>(undefined);
 
 ipcRenderer.on('tc', (_event, value) => tcRequests$.next(value));
 ipcRenderer.on('tonConnectRequest', (_event, value: TonConnectAppRequestPayload) =>
@@ -20,6 +22,9 @@ ipcRenderer.on('disconnect', (_event, value: AccountConnection) =>
     tonConnectDisconnects$.next(value)
 );
 ipcRenderer.on('refresh', () => refreshes$.next());
+ipcRenderer.on('update-available', (_event, value: UpdateInfo) =>
+    updateAvailable$.next(value)
+);
 
 contextBridge.exposeInMainWorld('backgroundApi', {
     platform: () => process.platform,
@@ -42,5 +47,11 @@ contextBridge.exposeInMainWorld('backgroundApi', {
     },
     onRefresh: (callback: () => void) => {
         refreshes$.subscribe(callback);
+    },
+    onUpdateAvailable: (callback: (value: UpdateInfo) => void) => {
+        updateAvailable$.subscribe(callback);
+        if (updateAvailable$.value !== undefined) {
+            callback(updateAvailable$.value);
+        }
     }
 });

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -48,10 +48,11 @@ contextBridge.exposeInMainWorld('backgroundApi', {
     onRefresh: (callback: () => void) => {
         refreshes$.subscribe(callback);
     },
-    onUpdateAvailable: (callback: (value: UpdateInfo) => void) => {
-        updateAvailable$.subscribe(callback);
+    onUpdateAvailable: (callback: (value: UpdateInfo) => void): (() => void) => {
+        const unsubscribe = updateAvailable$.subscribe(callback);
         if (updateAvailable$.value !== undefined) {
             callback(updateAvailable$.value);
         }
+        return unsubscribe;
     }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4731,6 +4731,7 @@ __metadata:
     ts-node: "npm:^10.0.0"
     typescript: "npm:^4.9.4"
     update-electron-app: "npm:^3.0.0"
+    vitest: "npm:^3.2.4"
     webpack: "npm:^5.104.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
resolves https://linear.app/theopenplatform/issue/TK-1187/update-available-banner-for-linux

Electron's built-in autoUpdater (used via update-electron-app) doesn't support Linux builds today are unsigned so updates fail silently. This adds a renderer banner that polls the GitHub Releases API in the main process and notifies users when a newer version is available, with a Download button that opens the release page in the default browser.

Other changes:
- forge.config.ts: build AppImage for arm64 in addition to x64
- index.ts: skip update-electron-app on Linux to avoid log spam

Banner is gated to non-macOS only; macOS uses Squirrel.Mac via update-electron-app and already gets a native update notification.