### PR TITLE
fix(desktop): bundle libsecret in Linux artifacts (#374)

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -12,6 +12,8 @@ import type { NotaryToolCredentials } from '@electron/notarize/lib/types';
 import path from 'path';
 
 import { MakerDebConfigOptions } from '@electron-forge/maker-deb/dist/Config';
+import { spawnSync } from 'child_process';
+import { existsSync, readdirSync, renameSync, rmSync, unlinkSync } from 'fs';
 import { mainConfig } from './webpack.main.config';
 import { rendererConfig } from './webpack.renderer.config';
 import { mainWindowName } from './src/constants';
@@ -19,6 +21,67 @@ import { mainWindowName } from './src/constants';
 const isDev = process.env.NODE_ENV === 'development';
 const isPrerelease = process.env.GITHUB_REF_NAME?.includes('-') ?? false;
 const githubToken = process.env.GITHUB_TOKEN;
+
+// Bundle libsecret + transitive deps into the AppImage so it runs on systems
+// where libsecret is not preinstalled. See github.com/tonkeeper/tonkeeper-web/issues/374
+function bundleLibsecretIntoAppImage(appImagePath: string) {
+    const workDir = path.dirname(appImagePath);
+    const linuxdeploy = process.env.LINUXDEPLOY_PATH || 'linuxdeploy';
+    const libsecret = process.env.LIBSECRET_PATH || '/usr/lib/x86_64-linux-gnu/libsecret-1.so.0';
+    const isRequired = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
+
+    const skipOrThrow = (message: string) => {
+        if (isRequired) throw new Error(message);
+        console.warn(`[libsecret bundling] ${message}, skipping ${appImagePath}`);
+    };
+
+    if (
+        spawnSync(linuxdeploy, ['--appimage-extract-and-run', '--version'], { stdio: 'ignore' })
+            .status !== 0
+    ) {
+        skipOrThrow('linuxdeploy not available');
+        return;
+    }
+    if (!existsSync(libsecret)) {
+        skipOrThrow(`${libsecret} not found`);
+        return;
+    }
+
+    const appDir = path.join(workDir, 'squashfs-root');
+    if (existsSync(appDir)) rmSync(appDir, { recursive: true, force: true });
+
+    const beforeFiles = new Set(readdirSync(workDir));
+    const extract = spawnSync(appImagePath, ['--appimage-extract'], {
+        cwd: workDir,
+        stdio: 'inherit'
+    });
+    if (extract.status !== 0) throw new Error('AppImage --appimage-extract failed');
+
+    const deploy = spawnSync(
+        linuxdeploy,
+        [
+            '--appimage-extract-and-run',
+            '--appdir',
+            appDir,
+            '--library',
+            libsecret,
+            '--output',
+            'appimage'
+        ],
+        { cwd: workDir, stdio: 'inherit' }
+    );
+    if (deploy.status !== 0) throw new Error('linuxdeploy --output appimage failed');
+
+    const newAppImage = readdirSync(workDir).find(
+        f => f.endsWith('.AppImage') && !beforeFiles.has(f)
+    );
+    if (!newAppImage) throw new Error('linuxdeploy did not produce a new AppImage');
+
+    unlinkSync(appImagePath);
+    renameSync(path.join(workDir, newAppImage), appImagePath);
+    rmSync(appDir, { recursive: true, force: true });
+    console.log(`[libsecret bundling] repacked ${appImagePath}`);
+}
 
 const schemes = ['tc', 'tonkeeper', 'tonkeeper-tc'];
 const squirrelRemoteReleases = githubToken
@@ -104,13 +167,17 @@ const config: ForgeConfig = {
         ),
         new MakerRpm(
             {
-                options: devAndRpmOptions
+                options: { ...devAndRpmOptions, requires: ['libsecret'] }
             },
             ['linux']
         ),
         new MakerDeb(
             {
-                options: { ...devAndRpmOptions, compression: 'xz' } as MakerDebConfigOptions
+                options: {
+                    ...devAndRpmOptions,
+                    compression: 'xz',
+                    depends: ['libsecret-1-0']
+                } as MakerDebConfigOptions
             },
             ['linux']
         ),
@@ -154,7 +221,20 @@ const config: ForgeConfig = {
             draft: true,
             prerelease: isPrerelease
         })
-    ]
+    ],
+    hooks: {
+        postMake: async (_config, makeResults) => {
+            for (const result of makeResults) {
+                if (result.platform !== 'linux' || result.arch !== 'x64') continue;
+                for (const artifact of result.artifacts) {
+                    if (artifact.endsWith('.AppImage')) {
+                        bundleLibsecretIntoAppImage(artifact);
+                    }
+                }
+            }
+            return makeResults;
+        }
+    }
 };
 
 export default config;


### PR DESCRIPTION
The desktop app uses keytar for OS keychain access, which on Linux loads libsecret-1.so.0 at runtime. On systems where libsecret is not preinstalled, the app crashes immediately with:

  Error: libsecret-1.so.0: cannot open shared object file

Fixes #374 with two changes:

1. MakerDeb and MakerRpm now declare libsecret as a runtime dependency (libsecret-1-0 / libsecret), so the package manager will install it or refuse to install without it.

2. The AppImage is self-contained, so a postMake hook in forge.config.ts runs linuxdeploy to bundle libsecret + transitive deps into the AppImage after make completes. CD installs linuxdeploy on the Linux x64 runner. The hook is a no-op if linuxdeploy isn't on PATH, so local builds without it still succeed.

The hook is gated to platform=linux, arch=x64. arm64 AppImage bundling needs a separate approach (arm64 runner or qemu) and will be a follow-up once arm64 AppImage builds are enabled.