### PR TITLE
fix(core): check manifest origin match

### DIFF
--- a/packages/core/src/service/tonConnect/__tests__/connectService.test.ts
+++ b/packages/core/src/service/tonConnect/__tests__/connectService.test.ts
@@ -1,7 +1,11 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TonConnectError } from '../../../entries/exception';
-import { SEND_TRANSACTION_ERROR_CODES, TonConnectNetwork } from '../../../entries/tonConnect';
+import {
+    ConnectRequest,
+    SEND_TRANSACTION_ERROR_CODES,
+    TonConnectNetwork
+} from '../../../entries/tonConnect';
 import { Network } from '../../../entries/network';
 import type { TonContract } from '../../../entries/wallet';
 import type { IStorage } from '../../../Storage';
@@ -27,8 +31,12 @@ vi.mock('../../../entries/account', async () => {
     };
 });
 
-const { sendBadRequestResponse, checkTonConnectFromAndNetwork, checkDappOriginMatchesManifest } =
-    await import('../connectService');
+const {
+    sendBadRequestResponse,
+    checkTonConnectFromAndNetwork,
+    checkDappOriginMatchesManifest,
+    getManifest
+} = await import('../connectService');
 
 const fakeStorage = {} as IStorage;
 
@@ -217,5 +225,56 @@ describe('checkDappOriginMatchesManifest', () => {
                 manifestUrl: 'not-a-url'
             })
         ).toBe(false);
+    });
+});
+
+describe('getManifest', () => {
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchSpy = vi.fn();
+        vi.stubGlobal('fetch', fetchSpy);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('rejects a manifest whose declared url origin does not match the hosting origin', async () => {
+        const maliciousManifest = {
+            url: 'https://getgems.io',
+            name: 'Getgems',
+            iconUrl: 'https://getgems.io/icon.png'
+        };
+
+        fetchSpy.mockResolvedValue({
+            status: 200,
+            json: async () => maliciousManifest
+        } as Response);
+
+        await expect(
+            getManifest({
+                manifestUrl: 'https://evil.com/tonconnect-manifest.json'
+            } as ConnectRequest)
+        ).rejects.toThrow('Manifest origin mismatch');
+    });
+
+    it('returns the manifest when origin of manifestUrl matches manifest.url', async () => {
+        const legitManifest = {
+            url: 'https://getgems.io',
+            name: 'Getgems',
+            iconUrl: 'https://getgems.io/icon.png'
+        };
+
+        fetchSpy.mockResolvedValue({
+            status: 200,
+            json: async () => legitManifest
+        } as Response);
+
+        const result = await getManifest({
+            manifestUrl: 'https://getgems.io/tonconnect-manifest.json'
+        } as ConnectRequest);
+
+        expect(result).toEqual(legitManifest);
     });
 });

--- a/packages/core/src/service/tonConnect/connectService.ts
+++ b/packages/core/src/service/tonConnect/connectService.ts
@@ -157,6 +157,14 @@ export const getManifest = async (request: ConnectRequest) => {
         throw new Error('Manifest is not valid');
     }
 
+    const requestOrigin = originFromUrl(request.manifestUrl);
+    const manifestOrigin = originFromUrl(manifest.url);
+    if (!requestOrigin || !manifestOrigin || requestOrigin !== manifestOrigin) {
+        throw new Error(
+            'Manifest origin mismatch — manifest must be hosted on the same origin as declared in manifest.url'
+        );
+    }
+
     return manifest;
 };
 


### PR DESCRIPTION
fixes https://linear.app/theopenplatform/issue/TK-1153/tonkeeper-web-tonconnect-identity-spoofing-manifest-origin-not
