### PR TITLE
testing auto pr review

### DIFF
--- a/packages/uikit/src/components/home/Jettons.tsx
+++ b/packages/uikit/src/components/home/Jettons.tsx
@@ -227,7 +227,7 @@ export const StakingPositionAsset = forwardRef<
             backgroundHighlighted={isFullWidth}
         >
             <ListItemPayload>
-                <StakingPoolIcon pool={stakingPosition.pool} size={isFullWidth ? 44 : 40} />
+                {/* <StakingPoolIcon pool={stakingPosition.pool} size={isFullWidth ? 44 : 40} /> */}
                 <TokenLayout
                     name={t('staking_staked')}
                     balance={balanceStr}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line UI comment-out with no logic, API, or data changes; minor visual inconsistency risk if left in production.
> 
> **Overview**
> **Staking position rows** on the home jetton list no longer show the pool icon: `StakingPoolIcon` in `StakingPositionAsset` is commented out, so those entries render text-only via `TokenLayout` (staked label, balance, pool name, pending subtitle, fiat).
> 
> `JettonAsset` still uses `StakingPoolIcon` for jetton rows tied to a staking pool; only the dedicated `StakingPositionAsset` path changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c795cf22c5a1c5e63516dbd49522e97311b54414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->