### PR TITLE
fix: appimage packaging

### DIFF
--- a/.github/workflows/desktop-build.yaml
+++ b/.github/workflows/desktop-build.yaml
@@ -55,6 +55,8 @@ jobs:
             APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
             APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
             DEBUG: electron*
+            LINUXDEPLOY_PATH: ${{ github.workspace }}/.cache/linuxdeploy-x86_64.AppImage
+            LIBSECRET_PATH: /usr/lib/x86_64-linux-gnu/libsecret-1.so.0
 
         steps:
             - name: Checkout to git repository
@@ -68,6 +70,17 @@ jobs:
             - name: Enable Corepack
               run: |
                   corepack enable
+
+            - name: Set up Linux AppImage packaging
+              if: runner.os == 'Linux' && matrix.command == 'make:intel'
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install --yes fakeroot libarchive-tools libfuse2 libsecret-1-0 libsecret-1-dev rpm zip
+                  mkdir -p "$(dirname "$LINUXDEPLOY_PATH")"
+                  curl --fail --location --output "$LINUXDEPLOY_PATH" \
+                      https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20251107-1/linuxdeploy-x86_64.AppImage
+                  echo "c20cd71e3a4e3b80c3483cef793cda3f4e990aca14014d23c544ca3ce1270b4d  $LINUXDEPLOY_PATH" | sha256sum --check
+                  chmod +x "$LINUXDEPLOY_PATH"
 
             - name: Decode service account into a file
               if: runner.os == 'macOS'

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -98,6 +98,8 @@ jobs:
             APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             DEBUG: electron*
+            LINUXDEPLOY_PATH: ${{ github.workspace }}/.cache/linuxdeploy-x86_64.AppImage
+            LIBSECRET_PATH: /usr/lib/x86_64-linux-gnu/libsecret-1.so.0
 
         steps:
             - name: Checkout
@@ -112,6 +114,17 @@ jobs:
 
             - name: Enable Corepack
               run: corepack enable
+
+            - name: Set up Linux AppImage packaging
+              if: runner.os == 'Linux' && matrix.command == 'publish:intel'
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install --yes fakeroot libarchive-tools libfuse2 libsecret-1-0 libsecret-1-dev rpm zip
+                  mkdir -p "$(dirname "$LINUXDEPLOY_PATH")"
+                  curl --fail --location --output "$LINUXDEPLOY_PATH" \
+                      https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20251107-1/linuxdeploy-x86_64.AppImage
+                  echo "c20cd71e3a4e3b80c3483cef793cda3f4e990aca14014d23c544ca3ce1270b4d  $LINUXDEPLOY_PATH" | sha256sum --check
+                  chmod +x "$LINUXDEPLOY_PATH"
 
             - name: Set version from tag
               run: node scripts/set-version.js

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,8 @@ jobs:
             APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             DEBUG: electron*
+            LINUXDEPLOY_PATH: ${{ github.workspace }}/.cache/linuxdeploy-x86_64.AppImage
+            LIBSECRET_PATH: /usr/lib/x86_64-linux-gnu/libsecret-1.so.0
 
         steps:
             - name: Checkout
@@ -68,6 +70,17 @@ jobs:
 
             - name: Enable Corepack
               run: corepack enable
+
+            - name: Set up Linux AppImage packaging
+              if: runner.os == 'Linux' && matrix.command == 'publish:intel'
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install --yes fakeroot libarchive-tools libfuse2 libsecret-1-0 libsecret-1-dev rpm zip
+                  mkdir -p "$(dirname "$LINUXDEPLOY_PATH")"
+                  curl --fail --location --output "$LINUXDEPLOY_PATH" \
+                      https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20251107-1/linuxdeploy-x86_64.AppImage
+                  echo "c20cd71e3a4e3b80c3483cef793cda3f4e990aca14014d23c544ca3ce1270b4d  $LINUXDEPLOY_PATH" | sha256sum --check
+                  chmod +x "$LINUXDEPLOY_PATH"
 
             - name: Set version from tag
               run: node scripts/set-version.js

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -17,10 +17,13 @@ import { existsSync, readdirSync, renameSync, rmSync, unlinkSync } from 'fs';
 import { mainConfig } from './webpack.main.config';
 import { rendererConfig } from './webpack.renderer.config';
 import { mainWindowName } from './src/constants';
+import { getRequestedArchitecture } from './src/forgeCli';
 
 const isDev = process.env.NODE_ENV === 'development';
 const isPrerelease = process.env.GITHUB_REF_NAME?.includes('-') ?? false;
 const githubToken = process.env.GITHUB_TOKEN;
+const requestedArchitecture = getRequestedArchitecture(process.argv);
+const isCI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
 
 // Bundle libsecret + transitive deps into the AppImage so it runs on systems
 // where libsecret is not preinstalled. See github.com/tonkeeper/tonkeeper-web/issues/374
@@ -28,10 +31,9 @@ function bundleLibsecretIntoAppImage(appImagePath: string) {
     const workDir = path.dirname(appImagePath);
     const linuxdeploy = process.env.LINUXDEPLOY_PATH || 'linuxdeploy';
     const libsecret = process.env.LIBSECRET_PATH || '/usr/lib/x86_64-linux-gnu/libsecret-1.so.0';
-    const isRequired = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
 
     const skipOrThrow = (message: string) => {
-        if (isRequired) throw new Error(message);
+        if (isCI) throw new Error(message);
         console.warn(`[libsecret bundling] ${message}, skipping ${appImagePath}`);
     };
 
@@ -68,7 +70,16 @@ function bundleLibsecretIntoAppImage(appImagePath: string) {
             '--output',
             'appimage'
         ],
-        { cwd: workDir, stdio: 'inherit' }
+        {
+            cwd: workDir,
+            stdio: 'inherit',
+            env: {
+                ...process.env,
+                LD_LIBRARY_PATH: [path.join(appDir, 'usr', 'lib'), process.env.LD_LIBRARY_PATH]
+                    .filter(Boolean)
+                    .join(path.delimiter)
+            }
+        }
     );
     if (deploy.status !== 0) throw new Error('linuxdeploy --output appimage failed');
 
@@ -181,7 +192,7 @@ const config: ForgeConfig = {
             },
             ['linux']
         ),
-        ...(['x64', 'arm64'].includes(process.argv[3])
+        ...(requestedArchitecture === 'x64'
             ? [
                   new MakerAppImage(
                       {
@@ -224,6 +235,21 @@ const config: ForgeConfig = {
     ],
     hooks: {
         postMake: async (_config, makeResults) => {
+            const linuxX64AppImages = makeResults
+                .filter(result => result.platform === 'linux' && result.arch === 'x64')
+                .flatMap(result =>
+                    result.artifacts.filter(artifact => artifact.endsWith('.AppImage'))
+                );
+
+            if (
+                isCI &&
+                process.platform === 'linux' &&
+                requestedArchitecture === 'x64' &&
+                linuxX64AppImages.length === 0
+            ) {
+                throw new Error('Linux x64 CI build did not produce an AppImage');
+            }
+
             for (const result of makeResults) {
                 if (result.platform !== 'linux' || result.arch !== 'x64') continue;
                 for (const artifact of result.artifacts) {

--- a/apps/desktop/src/forgeCli.test.ts
+++ b/apps/desktop/src/forgeCli.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { getRequestedArchitecture } from './forgeCli';
+
+describe('getRequestedArchitecture', () => {
+    it.each([
+        ['--arch=x64', ['node', 'electron-forge', 'publish', '--arch=x64']],
+        ['--arch x64', ['node', 'electron-forge', 'publish', '--arch', 'x64']],
+        ['-a x64', ['node', 'electron-forge', 'publish', '-a', 'x64']]
+    ])('parses x64 from %s', (_name, argv) => {
+        expect(getRequestedArchitecture(argv)).toBe('x64');
+    });
+
+    it('parses arm64', () => {
+        expect(
+            getRequestedArchitecture(['node', 'electron-forge', 'publish', '--arch=arm64'])
+        ).toBe('arm64');
+    });
+
+    it('returns undefined when the architecture is missing', () => {
+        expect(
+            getRequestedArchitecture(['node', 'electron-forge', 'publish', '--arch'])
+        ).toBeUndefined();
+    });
+
+    it('ignores unrelated arguments', () => {
+        expect(
+            getRequestedArchitecture(['node', 'electron-forge', 'publish', '--platform=linux'])
+        ).toBeUndefined();
+    });
+});

--- a/apps/desktop/src/forgeCli.ts
+++ b/apps/desktop/src/forgeCli.ts
@@ -1,0 +1,15 @@
+export function getRequestedArchitecture(argv: readonly string[]): string | undefined {
+    for (let index = 0; index < argv.length; index += 1) {
+        const argument = argv[index];
+
+        if (argument.startsWith('--arch=')) {
+            return argument.slice('--arch='.length) || undefined;
+        }
+
+        if (argument === '--arch' || argument === '-a') {
+            return argv[index + 1];
+        }
+    }
+
+    return undefined;
+}


### PR DESCRIPTION
**Summary**
Restores the x64 Linux AppImage release artifact reported in #702.

**Root cause**
After upgrading Electron Forge from 7.4.0 to 7.11.1, --arch=x64 was no longer represented at the positional process.argv[3] location expected by the Forge config. As a result, MakerAppImage was silently omitted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release artifact generation and CI packaging paths; mistakes could block releases or ship AppImages without libsecret bundling, but scope is limited to desktop Linux x64 packaging.
> 
> **Overview**
> Restores the **x64 Linux AppImage** release artifact that disappeared after Electron Forge 7.11.1 stopped exposing `--arch=x64` at the old `process.argv[3]` position, which caused `MakerAppImage` to be skipped silently.
> 
> Forge config now uses a new **`getRequestedArchitecture`** helper (with unit tests) to read `--arch` / `-a` from `process.argv`, gates `MakerAppImage` on **`x64` only**, and **fails Linux x64 CI** in `postMake` if no `.AppImage` is produced. Libsecret repackaging via `linuxdeploy` sets **`LD_LIBRARY_PATH`** during deploy so bundled libraries resolve correctly.
> 
> **Desktop build, pre-release, and release** workflows add a Linux intel-only step that installs packaging deps, pins and checksum-verifies `linuxdeploy`, and exports `LINUXDEPLOY_PATH` / `LIBSECRET_PATH` for the Forge hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4511c3bb1cd28b42ce7adca4a8f82cb6034a82f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->