### PR TITLE
feat(uikit): fetch 20 ledger accounts on import instead of 10

### DIFF
--- a/packages/uikit/src/pages/import/CreateLedgerWallet.tsx
+++ b/packages/uikit/src/pages/import/CreateLedgerWallet.tsx
@@ -173,15 +173,21 @@ const CheckboxStyled = styled(Checkbox)`
     padding-top: 0 !important;
 `;
 
+// How many derivation indexes (0..N-1) to query from the device during Ledger import.
+// Each index needs a Ledger getAddress round-trip, so N is a tradeoff: large enough to
+// cover wallets users keep on higher indexes, small enough that import stays responsive
+// and the selection list stays usable.
+const LEDGER_IMPORT_ACCOUNTS_COUNT = 20;
+
 const ChooseLedgerAccounts: FC<{
     tonTransport: LedgerTonTransport;
     onCancel: () => void;
     afterCompleted: () => void;
 }> = ({ tonTransport, onCancel, afterCompleted }) => {
     const { t } = useTranslation();
-    const totalAccounts = 20;
-    const { mutateAsync: getLedgerWallets, data: ledgerAccountData } =
-        useLedgerWallets(totalAccounts);
+    const { mutateAsync: getLedgerWallets, data: ledgerAccountData } = useLedgerWallets(
+        LEDGER_IMPORT_ACCOUNTS_COUNT
+    );
     const [selectedIndexes, setSelectedIndexes] = useState<Record<number, boolean>>({});
 
     const { mutateAsync: addAccountsMutation, isLoading: isAdding } = useAddLedgerAccountMutation();

--- a/packages/uikit/src/pages/import/CreateLedgerWallet.tsx
+++ b/packages/uikit/src/pages/import/CreateLedgerWallet.tsx
@@ -179,7 +179,7 @@ const ChooseLedgerAccounts: FC<{
     afterCompleted: () => void;
 }> = ({ tonTransport, onCancel, afterCompleted }) => {
     const { t } = useTranslation();
-    const totalAccounts = 10;
+    const totalAccounts = 20;
     const { mutateAsync: getLedgerWallets, data: ledgerAccountData } =
         useLedgerWallets(totalAccounts);
     const [selectedIndexes, setSelectedIndexes] = useState<Record<number, boolean>>({});


### PR DESCRIPTION
Increases the number of TON Ledger accounts fetched during hardware wallet import from 10 to 20, by bumping `totalAccounts` in `ChooseLedgerAccounts`. Users with wallets on higher derivation indexes (10–19) will now see them in the account selection list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)